### PR TITLE
Add missing development package 'apache2-dev'

### DIFF
--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update \
       lua5.2-dev \
       make \
       pkgconf \
-      wget
+      wget \
+      apache2-dev
 
 RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz \
  && tar -xvzf ssdeep-2.14.1.tar.gz \


### PR DESCRIPTION
Without apache2-dev, docker build fails:

```.txt
configure: looking for Apache module support via DSO through APXS
apxs:Error: /usr/bin/apr-1-config not found!.
configure: found apxs at /usr/local/apache2/bin/apxs
configure: checking httpd version
configure: httpd is recent enough
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
apxs:Error: /usr/bin/apr-1-config not found!.
checking for libpcre config script... /usr/bin/pcre-config
configure: using pcre v8.39
checking for libapr config script... no
configure: *** apr library not found.
configure: error: apr library is required
The command '/bin/sh -c git clone https://github.com/SpiderLabs/ModSecurity --branch v2.9.3 --depth 1  && cd ModSecurity  && ./autogen.sh  && ./configure  && make  && make install  && make clean' returned a non-zero code: 1
```
After adding the package, the build completes successfully.