### PR TITLE
Fix Apache build

### DIFF
--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends --no-install-suggests \
+      apache2-dev \
       automake \
       ca-certificates \
       g++ \


### PR DESCRIPTION
The Apache build fails because apxs no longer seems to be part of Apache.  
I added apache2-devel to fix the failing builds of the Apache image.