### PR TITLE
Add scheduled Docker build to GitHub Action

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,5 +1,8 @@
 name: Build images for Docker Hub
-on: push
+on: 
+  push:
+  schedule:
+  - cron: '0 12 * * MON'  # Run every Monday
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a scheduled build for the Docker images.
If we also want to work with tagging the Git repo, we could also add it like I did in https://github.com/coreruleset/modsecurity-crs-docker/pull/24.