### PR TITLE
fix(config): remove SecTmpDir directive, unsupported in v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,5 @@ $ docker run -p 8080:80 -e SERVER_NAME=myhost my-modsec
 * MODSEC_RESP_BODY_MIMETYPE - A string with the list of mime types that will be analyzed in the response (Default: `"text/plain text/html text/xml"`). You might consider adding `application/json` documented [here](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-\(v2.x\)#secresponsebodymimetype).
 * MODSEC_RULE_ENGINE - A string value enabling ModSecurity itself (Default: `on`)
 * MODSEC_TAG - A string indicating the default tag action, which will be inherited by the rules in the same configuration context (Default: `modsecurity`)
-* MODSEC_TMP_DIR - A string indicating the path where temporary files will be created (Default: `/tmp/modsecurity/tmp`)
+* MODSEC_TMP_DIR - ⚠️  `[DEPRECATED]` (see [this isssue](https://github.com/coreruleset/modsecurity-docker/issues/61)) A string indicating the path where temporary files will be created (Default: `/tmp/modsecurity/tmp`) 
 * MODSEC_UPLOAD_DIR - A string indicating the path where intercepted files will be stored (Default: `/tmp/modsecurity/upload`)

--- a/src/etc/modsecurity.d/modsecurity-override.conf
+++ b/src/etc/modsecurity.d/modsecurity-override.conf
@@ -37,7 +37,6 @@ SecRuleEngine ${MODSEC_RULE_ENGINE}
 
 SecStatusEngine On
 
-SecTmpDir ${MODSEC_TMP_DIR}
 SecTmpSaveUploadedFiles on
 
 SecUnicodeMapFile unicode.mapping 20127

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -83,7 +83,6 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
     MODSEC_RESP_BODY_MIMETYPE="text/plain text/html text/xml" \
     MODSEC_RULE_ENGINE=on \
     MODSEC_TAG=modsecurity \
-    MODSEC_TMP_DIR=/tmp/modsecurity/tmp \
     MODSEC_UPLOAD_DIR=/tmp/modsecurity/upload \
     PORT=80 \
     PROXY_TIMEOUT=60s \


### PR DESCRIPTION
Fixes #61.

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>