### PR TITLE
feat(alpine): add alpine images

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,20 +10,23 @@ jobs:
     strategy:
       matrix:
         image:
-        - v2-apache
-        - v3-nginx
+          - v2-apache
+          - v3-nginx
+        variant:
+          - ""
+          - "-alpine"
 
     steps:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
 
-    - name: Build ${{ matrix.image }}
-      run: docker build . -f ${{ matrix.image }}/Dockerfile
-           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -v)
-           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -vv)
-           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -vvv)
-           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -vvvv)
+    - name: Build ${{ matrix.image }}${{ matrix.variant }}
+      run: docker build . -f ${{ matrix.image }}/Dockerfile${{ matrix.variant }}
+           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -v ${{ matrix.variant }})
+           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -vv ${{ matrix.variant }})
+           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -vvv ${{ matrix.variant }})
+           --tag owasp/modsecurity:$(./version.sh ${{ matrix.image }} -vvvv ${{ matrix.variant }})
 
     - uses: azure/docker-login@v1
       if: github.ref == 'refs/heads/master'
@@ -31,6 +34,6 @@ jobs:
         username: ${{ secrets.dockerhub_user }}
         password: ${{ secrets.dockerhub_token }}
 
-    - name: Push ${{ matrix.image }}
+    - name: Push ${{ matrix.image }}${{ matrix.variant }}
       if: github.ref == 'refs/heads/master'
       run: docker push --all-tags owasp/modsecurity

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -9,19 +9,22 @@ jobs:
     strategy:
       matrix:
         image:
-        - v2-apache
-        - v3-nginx
+          - v2-apache
+          - v3-nginx
+        variant:
+          - ""
+          - "-alpine"
     steps:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
 
-    - name: Build ${{ matrix.image }}
-      run: docker build . -f ${{ matrix.image }}/Dockerfile --tag test
+    - name: Build ${{ matrix.image }}${{ matrix.variant }}
+      run: docker build . -f ${{ matrix.image }}/Dockerfile${{ matrix.variant }} --tag test
 
-    - name: Run ${{ matrix.image }}
-      run: docker run -d --name ${{ matrix.image }} test
+    - name: Run ${{ matrix.image }}${{ matrix.variant }}
+      run: docker run -d --name ${{ matrix.image }}${{ matrix.variant }} test
 
-    - name: Verify ${{ matrix.image }}
+    - name: Verify ${{ matrix.image }}${{ matrix.variant }}
       run: |
-        [ $(docker inspect ${{ matrix.image }} --format='{{.State.Running}}') = 'true' ]
+        [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }} --format='{{.State.Running}}') = 'true' ]

--- a/README.md
+++ b/README.md
@@ -9,31 +9,29 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* `3`, `3.0`, `3.0.4`, `nginx` ([master/v3-nginx/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.17 official base image*
-* `2`, `2.9`, `2.9.3`, `apache` ([master/v2-apache/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile)) – *last stable ModSecurity v2 on Apache 2.4 official base image*
+* `3`, `3.0`, `3.0.4`, `nginx` ([master/v3-nginx/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.20 official stable base image*
+* `2`, `2.9`, `2.9.3`, `apache` ([master/v2-apache/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile)) – *last stable ModSecurity v2 on Apache 2.4 official stable base image*
 
-### Older tagging scheme (soon to be deprecated)
+## Supported variants
 
-* `3.0.3-nginx`,  `3.0-nginx`,`3-nginx`, `latest` ([3.0/nginx/nginx/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/v3/nginx-nginx/Dockerfile))
-* `3.0.3-apache`, `3.0-apache`, `3-apache` ([3.0/apache/httpd/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/v3/apache-apache/Dockerfile))
-* `2.9.3-apache`,`2.9-apache`, `2-apache` ([2.9/apache/httpd/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/v2/apache-apache/Dockerfile))
-* `2.9.3-nginx`, `2.9-nginx`, `2-nginx` (2.9/nginx/nginx/Dockerfile)
-* `2.9-apache-ubuntu` ([2.9/apache/ubuntu/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/v2/ubuntu-apache/Dockerfile))
-* `2.9-nginx-ubuntu` ([2.9/nginx/ubuntu/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/v2/ubuntu-nginx/Dockerfile))
+We have support for [alpine linux](https://www.alpinelinux.org/) variants of the base images. Just add `-alpine` and you will get it. Examples:
+
+* `3-alpine`, `3.0-alpine`, `3.0.4-alpine`, `nginx-alpine` ([master/v3-nginx/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile-alpine) – *last stable ModSecurity v3 on Nginx 1.20 Alpine official stable base image*
+* `2-alpine`, `2.9-alpine`, `2.9.3-alpine`, `apache-alpine` ([master/v2-apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 Alpine official stable base image*
 
 ## Quick reference
 
 * **Where to get help**
 
-   [The CRS-Support Docker Repo](https://github.com/coreruleset/modsecurity-docker), [The Core Rule Set Slack Channel](https://join.slack.com/t/owasp/shared_invite/enQtNjExMTc3MTg0MzU4LTViMDg1MmJiMzMwZGUxZjgxZWQ1MTE0NTBlOTBhNjhhZDIzZTZiNmEwOTJlYjdkMzAxMGVhNDkwNDNiNjZiOWQ) (#coreruleset on owasp.slack.com), or [Stack Overflow](https://stackoverflow.com/questions/tagged/mod-security)
+[The CRS-Support Docker Repo](https://github.com/coreruleset/modsecurity-docker), [The Core Rule Set Slack Channel](https://join.slack.com/t/owasp/shared_invite/enQtNjExMTc3MTg0MzU4LTViMDg1MmJiMzMwZGUxZjgxZWQ1MTE0NTBlOTBhNjhhZDIzZTZiNmEwOTJlYjdkMzAxMGVhNDkwNDNiNjZiOWQ) (#coreruleset on owasp.slack.com), or [Stack Overflow](https://stackoverflow.com/questions/tagged/mod-security)
 
 * **Where to file issues**
 
-    [The Core Rule Set  Docker Repo](https://github.com/coreruleset/modsecurity-docker)
+[The Core Rule Set  Docker Repo](https://github.com/coreruleset/modsecurity-docker)
 
 * **Maintained By**
 
-   The OWASP Core Rule Set maintainers
+The OWASP Core Rule Set maintainers
 
 ## What is ModSecurity
 
@@ -45,7 +43,7 @@ This image only contains ModSecurity built from the code provided on the [ModSec
 
 1. Create a Dockerfile in your project and copy your code into container.
    ```
-   FROM modsecurity:2-apache
+   FROM owasp/modsecurity:apache
    COPY ./public-html/ .
    ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,43 @@ services:
     depends_on:
     - backend
 
+  apache-waf-alpine:
+    build:
+      context: .
+      dockerfile: v2-apache/Dockerfile-alpine
+    environment:
+      BACKEND: http://backend  # https://httpbin.org
+      PORT: "8080"
+      SSL_PORT: "4443"
+      METRICS_ALLOW_FROM: All
+    ports:
+    - "8080:8080"
+    - "4443:4443"
+    user: "10001"
+    depends_on:
+    - backend
+
   nginx-waf:
     build:
       context: .
       dockerfile: v3-nginx/Dockerfile
+    environment:
+      BACKEND: http://backend  # https://httpbin.org
+      PORT: "8080"
+      SSL_PORT: "4443"
+      # DNS_SERVER: "8.8.8.8"
+      METRICS_ALLOW_FROM: all
+    ports:
+    - "8081:8080"
+    - "4444:4443"
+    user: "10001"
+    depends_on:
+    - backend
+
+  nginx-waf-alpine:
+    build:
+      context: .
+      dockerfile: v3-nginx/Dockerfile-alpine
     environment:
       BACKEND: http://backend  # https://httpbin.org
       PORT: "8080"

--- a/v2-apache/Dockerfile-alpine
+++ b/v2-apache/Dockerfile-alpine
@@ -1,39 +1,53 @@
-FROM httpd:2.4 as build
+FROM httpd:2.4-alpine as build
 
 ARG MODSEC_VERSION
 ENV MODSEC_VERSION="${MODSEC_VERSION:-2.9.3}"
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update -qq \
-    && apt-get install -y -qq --no-install-recommends --no-install-suggests \
+# see https://httpd.apache.org/docs/2.4/install.html#requirements
+RUN set -eux; \
+    apk add --no-cache --virtual .build-deps \
     automake \
+    autoconf \
+    apr-dev \
+    apr-util-dev \
     ca-certificates \
+    coreutils \
+    curl-dev \
+    dpkg-dev dpkg \
+    geoip-dev \
+    gcc \
     g++ \
-    git \
-    libapr1-dev \
-    libaprutil1-dev \
-    libcurl4-gnutls-dev \
-    libpcre++-dev \
+    gnupg \
+    libc-dev \
+    libmaxminddb-dev \
+    libstdc++ \
+    linux-headers \
     libtool \
+    lmdb-dev \
     libxml2-dev \
-    libyajl-dev \
-    lua5.2-dev \
+    yajl-dev \
+    lua-dev \
     make \
-    pkgconf \
-    wget
+    openssl \
+    openssl-dev \
+    pcre-dev \
+    zlib-dev
 
+
+# This one is in edge still for Alpine, so just compile
 RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz \
-    && tar -xzf ssdeep-2.14.1.tar.gz \
+    && tar -xvzf ssdeep-2.14.1.tar.gz \
     && cd ssdeep-2.14.1 \
     && ./configure \
     && make \
     && make install \
     && make clean
 
-RUN git clone https://github.com/SpiderLabs/ModSecurity --branch v${MODSEC_VERSION} --depth 1 \
-    && cd ModSecurity \
+RUN wget --quiet https://github.com/SpiderLabs/ModSecurity/archive/refs/tags/v${MODSEC_VERSION}.tar.gz \
+    && tar -zxvf v${MODSEC_VERSION}.tar.gz \
+    && cd ModSecurity-${MODSEC_VERSION} \
     && ./autogen.sh \
-    && ./configure \
+    && ./configure --with-yajl --with-ssdeep --with-lmdb \
     && make \
     && make install \
     && make clean
@@ -46,7 +60,7 @@ RUN openssl req -x509 -days 365 -new \
     -keyout /usr/share/TLS/server.key \
     -out /usr/share/TLS/server.crt
 
-FROM httpd:2.4
+FROM httpd:2.4-alpine
 
 ARG MODSEC_VERSION
 ENV MODSEC_VERSION="${MODSEC_VERSION:-2.9.3}"
@@ -100,21 +114,17 @@ ENV ACCESSLOG=/var/log/apache2/access.log \
     TIMEOUT=60 \
     WORKER_CONNECTIONS=400
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update -qq \
-    && apt-get install -qq -y --no-install-recommends --no-install-suggests \
+RUN set -eux; \
+    apk add --no-cache \
     ca-certificates \
-    libcurl3-gnutls \
     libxml2 \
-    libyajl2 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /etc/modsecurity.d/ \
-    && mkdir -p /var/log/apache2/
+    moreutils \
+    tzdata \
+    yajl
 
 COPY --from=build /usr/local/apache2/modules/mod_security2.so                  /usr/local/apache2/modules/mod_security2.so
-COPY --from=build /usr/local/apache2/ModSecurity/modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf
-COPY --from=build /usr/local/apache2/ModSecurity/unicode.mapping               /etc/modsecurity.d/unicode.mapping
+COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf
+COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/unicode.mapping               /etc/modsecurity.d/unicode.mapping
 COPY --from=build /usr/local/lib/libfuzzy.so.2.1.0                             /usr/local/lib/libfuzzy.so.2.1.0
 COPY --from=build /usr/local/bin/ssdeep                                        /usr/local/bin/ssdeep
 COPY --from=build /usr/share/TLS/server.key                                    /usr/local/apache2/conf/server.key
@@ -122,11 +132,8 @@ COPY --from=build /usr/share/TLS/server.crt                                    /
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY v2-apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 
-RUN ln -s libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so \
-    && ln -s libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so.2 \
-    && ldconfig
-
-RUN sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf \
+RUN ln -s /usr/local/lib/libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so.2 \
+    && sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf \
     && sed -i -E 's|(ServerTokens) Full|\1 Prod|' /usr/local/apache2/conf/extra/httpd-default.conf \
     && sed -i -E 's|#(ServerName) www.example.com:80|\1 ${SERVER_NAME}|' /usr/local/apache2/conf/httpd.conf \
     && sed -i -E 's|#(LoadModule unique_id_module)|\1|' /usr/local/apache2/conf/httpd.conf \
@@ -145,7 +152,9 @@ RUN sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf
     && echo 'Include conf/extra/httpd-modsecurity.conf' >> /usr/local/apache2/conf/httpd.conf \
     && sed -i -E 's|(MaxRequestWorkers[ ]*)[0-9]*|\1${WORKER_CONNECTIONS}|' /usr/local/apache2/conf/extra/httpd-mpm.conf
 
-RUN chgrp -R 0 /var/log/ /usr/local/apache2/ \
+RUN mkdir -p /var/log/apache2 \
+    && chown www-data /var/log/apache2 \
+    && chgrp -R 0 /var/log/ /usr/local/apache2/ \
     && chmod -R g=u /var/log/ /usr/local/apache2/
 
 # Use httpd-foreground from upstream

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -1,142 +1,149 @@
-FROM nginx:1.20.1 as build
+ARG NGINX_VERSION="1.20.1"
 
-LABEL version="3.0.4"
-LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
+FROM nginx:${NGINX_VERSION} as build
+
+ARG MODSEC_VERSION
+ENV MODSEC_VERSION="${MODSEC_VERSION:-3.0.4}"
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      automake \
-      cmake \
-      doxygen \
-      g++ \
-      git \
-      libcurl4-gnutls-dev \
-      libgeoip-dev \
-      liblua5.3-dev \
-      libpcre++-dev \
-      libtool \
-      libxml2-dev \
-      make \
-      ruby \
-      wget \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+     && apt-get install -y --no-install-recommends \
+     automake \
+     cmake \
+     doxygen \
+     g++ \
+     git \
+     libcurl4-gnutls-dev \
+     libgeoip-dev \
+     liblua5.3-dev \
+     libpcre++-dev \
+     libtool \
+     libxml2-dev \
+     make \
+     ruby \
+     wget \
+     zlib1g-dev \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /sources
 
 RUN git clone https://github.com/LMDB/lmdb --branch LMDB_0.9.23 --depth 1 \
- && make -C lmdb/libraries/liblmdb install
+     && make -C lmdb/libraries/liblmdb install
 
 RUN git clone https://github.com/lloyd/yajl --branch 2.1.0 --depth 1 \
- && cd yajl \
- && ./configure \
- && make install
+     && cd yajl \
+     && ./configure \
+     && make install
 
 RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz \
- && tar -xvzf ssdeep-2.14.1.tar.gz \
- && cd ssdeep-2.14.1 \
- && ./configure \
- && make install
+     && tar -xvzf ssdeep-2.14.1.tar.gz \
+     && cd ssdeep-2.14.1 \
+     && ./configure \
+     && make install
 
-RUN git clone https://github.com/SpiderLabs/ModSecurity --branch v3.0.4 --depth 1 \
- && cd ModSecurity \
- && ./build.sh \
- && git submodule init \
- && git submodule update \
- && ./configure --with-yajl=/sources/yajl/build/yajl-2.1.0/ \
- && make install
+RUN git clone https://github.com/SpiderLabs/ModSecurity --branch v${MODSEC_VERSION} --depth 1 \
+     && cd ModSecurity \
+     && ./build.sh \
+     && git submodule init \
+     && git submodule update \
+     && ./configure --with-yajl=/sources/yajl/build/yajl-2.1.0/ \
+     && make install
+
+# We use master
+RUN git clone -b master --depth 1 https://github.com/SpiderLabs/ModSecurity-nginx.git \
+     && wget --quiet http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+     && tar -xzf nginx-${NGINX_VERSION}.tar.gz \
+     && cd ./nginx-${NGINX_VERSION} \
+     && ./configure --with-compat --add-dynamic-module=../ModSecurity-nginx \
+     && make modules \
+     && cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules/ \
+     && mkdir /etc/modsecurity.d \
+     && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended \
+     -O /etc/modsecurity.d/modsecurity.conf \
+     && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping \
+     -O /etc/modsecurity.d/unicode.mapping
 
 # Generate self-signed certificates (if needed)
 RUN mkdir -p /usr/share/TLS
 COPY v3-nginx/openssl.conf /usr/share/TLS
 RUN openssl req -x509 -days 365 -new \
-      -config /usr/share/TLS/openssl.conf \
-      -keyout /usr/share/TLS/server.key \
-      -out /usr/share/TLS/server.crt
+     -config /usr/share/TLS/openssl.conf \
+     -keyout /usr/share/TLS/server.key \
+     -out /usr/share/TLS/server.crt
 
-FROM nginx:1.20.1
+FROM nginx:${NGINX_VERSION}
+
+ARG MODSEC_VERSION
+ENV MODSEC_VERSION="${MODSEC_VERSION:-3.0.4}"
+
+LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
+
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV ACCESSLOG=/var/log/nginx/access.log \
-    BACKEND=http://localhost:80 \
-    DNS_SERVER= \
-    ERRORLOG=/var/log/nginx/error.log \
-    LOGLEVEL=warn \
-    METRICS_ALLOW_FROM='127.0.0.0/24' \
-    METRICS_DENY_FROM='all' \
-    METRICSLOG=/dev/null \
-    MODSEC_AUDIT_LOG_FORMAT=JSON \
-    MODSEC_AUDIT_LOG_TYPE=Serial \
-    MODSEC_AUDIT_LOG=/dev/stdout \
-    MODSEC_AUDIT_STORAGE=/var/log/modsecurity/audit/ \
-    MODSEC_DATA_DIR=/tmp/modsecurity/data \
-    MODSEC_DEBUG_LOG=/dev/null \
-    MODSEC_DEBUG_LOGLEVEL=0 \
-    MODSEC_PCRE_MATCH_LIMIT_RECURSION=100000 \
-    MODSEC_PCRE_MATCH_LIMIT=100000 \
-    MODSEC_REQ_BODY_ACCESS=on \
-    MODSEC_REQ_BODY_LIMIT=13107200 \
-    MODSEC_REQ_BODY_NOFILES_LIMIT=131072 \
-    MODSEC_RESP_BODY_ACCESS=on \
-    MODSEC_RESP_BODY_LIMIT=1048576 \
-    MODSEC_RESP_BODY_MIMETYPE="text/plain text/html text/xml" \
-    MODSEC_RULE_ENGINE=on \
-    MODSEC_TAG=modsecurity \
-    MODSEC_TMP_DIR=/tmp/modsecurity/tmp \
-    MODSEC_UPLOAD_DIR=/tmp/modsecurity/upload \
-    PORT=80 \
-    PROXY_TIMEOUT=60s \
-    PROXY_SSL_CERT_KEY=/etc/nginx/conf/server.key \
-    PROXY_SSL_CERT=/etc/nginx/conf/server.crt \
-    PROXY_SSL_VERIFY=off \
-    SERVER_NAME=localhost \
-    SSL_PORT=443 \
-    TIMEOUT=60s \
-    WORKER_CONNECTIONS=1024 \
-    LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
+     BACKEND=http://localhost:80 \
+     DNS_SERVER= \
+     ERRORLOG=/var/log/nginx/error.log \
+     LOGLEVEL=warn \
+     METRICS_ALLOW_FROM='127.0.0.0/24' \
+     METRICS_DENY_FROM='all' \
+     METRICSLOG=/dev/null \
+     MODSEC_AUDIT_LOG_FORMAT=JSON \
+     MODSEC_AUDIT_LOG_TYPE=Serial \
+     MODSEC_AUDIT_LOG=/dev/stdout \
+     MODSEC_AUDIT_STORAGE=/var/log/modsecurity/audit/ \
+     MODSEC_DATA_DIR=/tmp/modsecurity/data \
+     MODSEC_DEBUG_LOG=/dev/null \
+     MODSEC_DEBUG_LOGLEVEL=0 \
+     MODSEC_PCRE_MATCH_LIMIT_RECURSION=100000 \
+     MODSEC_PCRE_MATCH_LIMIT=100000 \
+     MODSEC_REQ_BODY_ACCESS=on \
+     MODSEC_REQ_BODY_LIMIT=13107200 \
+     MODSEC_REQ_BODY_NOFILES_LIMIT=131072 \
+     MODSEC_RESP_BODY_ACCESS=on \
+     MODSEC_RESP_BODY_LIMIT=1048576 \
+     MODSEC_RESP_BODY_MIMETYPE="text/plain text/html text/xml" \
+     MODSEC_RULE_ENGINE=on \
+     MODSEC_TAG=modsecurity \
+     MODSEC_TMP_DIR=/tmp/modsecurity/tmp \
+     MODSEC_UPLOAD_DIR=/tmp/modsecurity/upload \
+     PORT=80 \
+     PROXY_TIMEOUT=60s \
+     PROXY_SSL_CERT_KEY=/etc/nginx/conf/server.key \
+     PROXY_SSL_CERT=/etc/nginx/conf/server.crt \
+     PROXY_SSL_VERIFY=off \
+     SERVER_NAME=localhost \
+     SSL_PORT=443 \
+     TIMEOUT=60s \
+     WORKER_CONNECTIONS=1024 \
+     LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      ca-certificates \
-      gcc \
-      git \
-      libcurl4-gnutls-dev \
-      liblua5.3-dev \
-      libpcre++-dev \
-      libxml2-dev \
-      make \
-      wget \
-      moreutils \
-      zlib1g-dev && \
-      rm -rf /var/lib/apt/lists/* && \
-      apt-get clean \
- && git clone https://github.com/SpiderLabs/ModSecurity-nginx --branch v1.0.1 --depth 1 \
- && mkdir /etc/nginx/ssl/
+     && apt-get install -y --no-install-recommends \
+     ca-certificates \
+     libcurl4-gnutls-dev \
+     liblua5.3 \
+     libxml2 \
+     moreutils \
+     && rm -rf /var/lib/apt/lists/* \
+     && apt-get clean \
+     && mkdir /etc/nginx/ssl
 
 COPY --from=build /usr/local/modsecurity/ /usr/local/modsecurity/
 COPY --from=build /usr/local/lib/ /usr/local/lib/
 COPY --from=build /usr/share/TLS/server.key /etc/nginx/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt /etc/nginx/conf/server.crt
+COPY --from=build /etc/nginx/modules/ngx_http_modsecurity_module.so /etc/nginx/modules/ngx_http_modsecurity_module.so
+COPY --from=build /etc/modsecurity.d/unicode.mapping /etc/modsecurity.d/unicode.mapping
+COPY --from=build /etc/modsecurity.d/modsecurity.conf /etc/modsecurity.d/modsecurity.conf
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY v3-nginx/conf.d/*.conf /etc/nginx/conf.d/
 COPY v3-nginx/nginx.conf /etc/nginx/
 COPY v3-nginx/docker-entrypoint.sh /
 
-RUN version="$(/usr/sbin/nginx -v 2>&1 | cut -d '/' -f 2)" \
- && wget --quiet http://nginx.org/download/nginx-"$version".tar.gz \
- && tar -xvzf nginx-"$version".tar.gz \
- && cd /nginx-"$version" \
- && ./configure --with-compat --add-dynamic-module=../ModSecurity-nginx \
- && make modules \
- && cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules/ \
- && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended \
-    -O /etc/modsecurity.d/modsecurity.conf \
- && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping \
-    -O /etc/modsecurity.d/unicode.mapping
-
 RUN chgrp -R 0 /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/ \
- && chmod -R g=u /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/
+     && chmod -R g=u /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -1,0 +1,146 @@
+ARG NGINX_VERSION="1.20.1"
+
+FROM nginx:${NGINX_VERSION}-alpine as build
+
+ARG MODSEC_VERSION
+ENV MODSEC_VERSION="${MODSEC_VERSION:-3.0.4}"
+
+RUN set -eux; \
+    apk add --no-cache --virtual .build-deps \
+    autoconf \
+    automake \
+    ca-certificates \
+    coreutils \        
+    curl-dev \
+    g++ \
+    gcc \
+    geoip-dev \
+    git \
+    libc-dev \
+    libmaxminddb-dev \
+    libstdc++ \
+    libtool \
+    libxml2-dev \
+    linux-headers \
+    lmdb-dev \
+    make \
+    openssl \
+    openssl-dev \
+    pcre-dev \
+    yajl-dev \
+    zlib-dev
+
+WORKDIR /sources
+
+RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz \
+    && tar -xvzf ssdeep-2.14.1.tar.gz \
+    && cd ssdeep-2.14.1 \
+    && ./configure \
+    && make install
+
+RUN git clone https://github.com/SpiderLabs/ModSecurity --branch v"$MODSEC_VERSION" --depth 1 \
+    && cd ModSecurity \
+    && ./build.sh \
+    && git submodule init \
+    && git submodule update \
+    && ./configure --with-yajl --with-ssdeep --with-lmdb \
+    && make install
+
+# We use master
+RUN git clone -b master --depth 1 https://github.com/SpiderLabs/ModSecurity-nginx.git \
+    && wget --quiet http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+    && tar -xzf nginx-${NGINX_VERSION}.tar.gz \
+    && cd ./nginx-${NGINX_VERSION} \
+    && ./configure --with-compat --add-dynamic-module=../ModSecurity-nginx \
+    && make modules \
+    && cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules/ \
+    && mkdir /etc/modsecurity.d \
+    && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended \
+    -O /etc/modsecurity.d/modsecurity.conf \
+    && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping \
+    -O /etc/modsecurity.d/unicode.mapping
+
+# Generate self-signed certificates (if needed)
+RUN mkdir -p /usr/share/TLS
+COPY v3-nginx/openssl.conf /usr/share/TLS
+RUN openssl req -x509 -days 365 -new \
+    -config /usr/share/TLS/openssl.conf \
+    -keyout /usr/share/TLS/server.key \
+    -out /usr/share/TLS/server.crt
+
+FROM nginx:${NGINX_VERSION}-alpine
+
+ARG MODSEC_VERSION
+ENV MODSEC_VERSION="${MODSEC_VERSION:-3.0.4}"
+
+LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
+
+ENV ACCESSLOG=/var/log/nginx/access.log \
+    BACKEND=http://localhost:80 \
+    DNS_SERVER= \
+    ERRORLOG=/var/log/nginx/error.log \
+    LOGLEVEL=warn \
+    METRICS_ALLOW_FROM='127.0.0.0/24' \
+    METRICS_DENY_FROM='all' \
+    METRICSLOG=/dev/null \
+    MODSEC_AUDIT_LOG_FORMAT=JSON \
+    MODSEC_AUDIT_LOG_TYPE=Serial \
+    MODSEC_AUDIT_LOG=/dev/stdout \
+    MODSEC_AUDIT_STORAGE=/var/log/modsecurity/audit/ \
+    MODSEC_DATA_DIR=/tmp/modsecurity/data \
+    MODSEC_DEBUG_LOG=/dev/null \
+    MODSEC_DEBUG_LOGLEVEL=0 \
+    MODSEC_PCRE_MATCH_LIMIT_RECURSION=100000 \
+    MODSEC_PCRE_MATCH_LIMIT=100000 \
+    MODSEC_REQ_BODY_ACCESS=on \
+    MODSEC_REQ_BODY_LIMIT=13107200 \
+    MODSEC_REQ_BODY_NOFILES_LIMIT=131072 \
+    MODSEC_RESP_BODY_ACCESS=on \
+    MODSEC_RESP_BODY_LIMIT=1048576 \
+    MODSEC_RESP_BODY_MIMETYPE="text/plain text/html text/xml" \
+    MODSEC_RULE_ENGINE=on \
+    MODSEC_TAG=modsecurity \
+    MODSEC_TMP_DIR=/tmp/modsecurity/tmp \
+    MODSEC_UPLOAD_DIR=/tmp/modsecurity/upload \
+    PORT=80 \
+    PROXY_TIMEOUT=60s \
+    PROXY_SSL_CERT_KEY=/etc/nginx/conf/server.key \
+    PROXY_SSL_CERT=/etc/nginx/conf/server.crt \
+    PROXY_SSL_VERIFY=off \
+    SERVER_NAME=localhost \
+    SSL_PORT=443 \
+    TIMEOUT=60s \
+    WORKER_CONNECTIONS=1024 \
+    LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
+
+RUN apk add --no-cache \
+    curl-dev \
+    libmaxminddb-dev \
+    libstdc++ \
+    libxml2-dev \
+    lmdb-dev \
+    moreutils \
+    tzdata \
+    yajl && \
+    mkdir /etc/nginx/ssl/ && \
+    chown -R nginx:nginx /usr/share/nginx
+
+COPY --from=build /usr/local/modsecurity/ /usr/local/modsecurity/
+COPY --from=build /usr/local/lib/ /usr/local/lib/
+COPY --from=build /etc/nginx/modules/ngx_http_modsecurity_module.so /etc/nginx/modules/ngx_http_modsecurity_module.so 
+COPY --from=build /usr/share/TLS/server.key /etc/nginx/conf/server.key
+COPY --from=build /usr/share/TLS/server.crt /etc/nginx/conf/server.crt
+COPY --from=build /etc/modsecurity.d/unicode.mapping /etc/modsecurity.d/unicode.mapping
+COPY --from=build /etc/modsecurity.d/modsecurity.conf /etc/modsecurity.d/modsecurity.conf
+COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
+COPY v3-nginx/conf.d/*.conf /etc/nginx/conf.d/
+COPY v3-nginx/nginx.conf /etc/nginx/
+COPY v3-nginx/docker-entrypoint.sh /
+
+RUN chgrp -R 0 /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/ \
+    && chmod -R g=u /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/
+
+WORKDIR /usr/share/nginx/html
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/v3-nginx/docker-entrypoint.sh
+++ b/v3-nginx/docker-entrypoint.sh
@@ -1,19 +1,14 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
-export DNS_SERVER=${DNS_SERVER:-$(cat /etc/resolv.conf |grep -i '^nameserver'|head -n1|cut -d ' ' -f2)}
+export DNS_SERVER=${DNS_SERVER:-$(grep -i '^nameserver' /etc/resolv.conf |head -n1|cut -d ' ' -f2)}
 
 ENV_VARIABLES=$(awk 'BEGIN{for(v in ENVIRON) print "$"v}')
 
-FILES=(
-    etc/nginx/nginx.conf
-    etc/nginx/conf.d/default.conf
-    etc/nginx/conf.d/logging.conf
-    etc/modsecurity.d/modsecurity-override.conf
-)
+FILES="/etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/logging.conf /etc/modsecurity.d/modsecurity-override.conf"
 
-for FILE in ${FILES[*]}; do
-    if [ -f $FILE ]; then
-        envsubst "$ENV_VARIABLES" <$FILE | sponge $FILE
+for FILE in $FILES; do
+    if [ -f "$FILE" ]; then
+        envsubst "$ENV_VARIABLES" <"$FILE" | sponge "$FILE"
     fi
 done
 

--- a/version.sh
+++ b/version.sh
@@ -1,33 +1,36 @@
 #!/bin/sh
 #
-# Expects a semver "LABEL version" in a Dockerfile,
+# Expects a semver "MODSEC_VERSION=version" in a Dockerfile,
 # parses it into <major>.<minor>.<patch>
 #
 TARGET="${1%%/}"
 TYPE="$2"
+# Variant allows us to generate variants like '-alpine'
+VARIANT="$3"
 
 [ -z "$TARGET" ] && {
     echo "Usage: $0 <directory> [-v|-vv|-vvv|-vvvv]"
     exit 1
 }
 
-version=$(grep "LABEL version" "$TARGET/Dockerfile" | sed -e 's/^.*="//' -e 's/"$//')
+version=$(grep -m1 "ARG MODSEC_VERSION" "$TARGET/Dockerfile${VARIANT}" | cut -f2 -d=)
 major="${version%%.*}"
 patch="${version##*.}"
 nomaj="${version#$major.}"
 minor="${nomaj%.$patch}"
 humanized="${TARGET#*-}"
+variant="${VARIANT}"
 
 case "$TYPE" in
     -v)
-        echo "${major}"
+        echo "${major}${variant}"
         ;;
     -vv)
-        echo "${major}.${minor}"
+        echo "${major}.${minor}${variant}"
         ;;
     -vvv)
-        echo "${major}.${minor}.${patch}"
+        echo "${major}.${minor}.${patch}${variant}"
         ;;
     *)
-        echo "${humanized}"
+        echo "${humanized}${variant}"
 esac


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- Adds Alpine Linux based images.
- `docker-entrypoint.sh` was changed to make it POSIX compliant, so we don't need to install bash shell in Alpine
- Still no build using GHA, will add that in next commits.