### PR TITLE
[nginx] deny first everything, then allow specific ip

### DIFF
--- a/v3-nginx/conf.d/default.conf
+++ b/v3-nginx/conf.d/default.conf
@@ -54,8 +54,8 @@ server {
 
     location /metrics/nginx {
         access_log off;
-        allow ${METRICS_ALLOW_FROM};
         deny ${METRICS_DENY_FROM};
+        allow ${METRICS_ALLOW_FROM};
         proxy_store off;
         stub_status;
     }


### PR DESCRIPTION
in the current situation everything would be blocked by the METRICS_ALLOW_FROM default 'all'

hopefully I saw this correctly, but in our case we had to switch that.