### PR TITLE
feat(modsec): upgrade to apache module to v2.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 ## Supported tags and respective `Dockerfile` links
 
 * `3`, `3.0`, `3.0.5`, `nginx` ([master/v3-nginx/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.20 official stable base image*
-* `2`, `2.9`, `2.9.3`, `apache` ([master/v2-apache/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile)) – *last stable ModSecurity v2 on Apache 2.4 official stable base image*
+* `2`, `2.9`, `2.9.4`, `apache` ([master/v2-apache/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile)) – *last stable ModSecurity v2 on Apache 2.4 official stable base image*
 
 ## Supported variants
 
 We have support for [alpine linux](https://www.alpinelinux.org/) variants of the base images. Just add `-alpine` and you will get it. Examples:
 
 * `3-alpine`, `3.0-alpine`, `3.0.5-alpine`, `nginx-alpine` ([master/v3-nginx/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile-alpine) – *last stable ModSecurity v3 on Nginx 1.20 Alpine official stable base image*
-* `2-alpine`, `2.9-alpine`, `2.9.3-alpine`, `apache-alpine` ([master/v2-apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 Alpine official stable base image*
+* `2-alpine`, `2.9-alpine`, `2.9.4-alpine`, `apache-alpine` ([master/v2-apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 Alpine official stable base image*
 
 ## Quick reference
 

--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -1,6 +1,6 @@
 FROM httpd:2.4 as build
 
-ARG MODSEC_VERSION=2.9.3
+ARG MODSEC_VERSION=2.9.4
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && apt-get update -qq \
@@ -47,7 +47,7 @@ RUN openssl req -x509 -days 365 -new \
 
 FROM httpd:2.4
 
-ARG MODSEC_VERSION=2.9.3
+ARG MODSEC_VERSION=2.9.4
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 

--- a/v2-apache/Dockerfile-alpine
+++ b/v2-apache/Dockerfile-alpine
@@ -1,6 +1,6 @@
 FROM httpd:2.4-alpine as build
 
-ARG MODSEC_VERSION=2.9.3
+ARG MODSEC_VERSION=2.9.4
 
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN set -eux; \
@@ -61,7 +61,7 @@ RUN openssl req -x509 -days 365 -new \
 
 FROM httpd:2.4-alpine
 
-ARG MODSEC_VERSION=2.9.3
+ARG MODSEC_VERSION=2.9.4
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Upgrades apache v2 to latest 2.9.4.