### PR TITLE
Fix uids tmp

### DIFF
--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -114,7 +114,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     && mkdir -p /tmp/modsecurity/data \
     && mkdir -p /tmp/modsecurity/upload \
     && mkdir -p /tmp/modsecurity/tmp \
-    && chown -R www-data /tmp/modsecurity \
+    && chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity \
     && mkdir -p /var/log/apache2/
 
 COPY --from=build /usr/local/apache2/modules/mod_security2.so                  /usr/local/apache2/modules/mod_security2.so

--- a/v2-apache/Dockerfile-alpine
+++ b/v2-apache/Dockerfile-alpine
@@ -159,7 +159,7 @@ RUN mkdir -p /var/log/apache2 \
     && mkdir -p /tmp/modsecurity/data \
     && mkdir -p /tmp/modsecurity/upload \
     && mkdir -p /tmp/modsecurity/tmp \
-    && chown -R www-data /var/log/apache2 /tmp/modsecurity \
+    && chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity /var/log/apache2 \
     && chgrp -R 0 /var/log/ /usr/local/apache2/ \
     && chmod -R g=u /var/log/ /usr/local/apache2/
 

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -131,7 +131,7 @@ RUN apt-get update \
      && apt-get clean \
      && mkdir /etc/nginx/ssl \
      && mkdir -p /tmp/modsecurity/{data,upload,tmp} \
-     && chown -R www-data /tmp/modsecurity
+     && chown -R nginx:nginx /tmp/modsecurity
 
 COPY --from=build /usr/local/modsecurity/ /usr/local/modsecurity/
 COPY --from=build /usr/local/lib/ /usr/local/lib/


### PR DESCRIPTION
While both images create and change users to www-data (see upstream build), the `user` in default configuration is the one changed in this PR.