### PR TITLE
fix(cve): update modsecurity version

### DIFF
--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -1,41 +1,48 @@
-FROM httpd:2.4 as build
+ARG APACHE_VERSION=2.4
 
-ARG MODSEC_VERSION=2.9.4
+FROM httpd:${APACHE_VERSION} as build
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update -qq \
-    && apt-get install -y -qq --no-install-recommends --no-install-suggests \
-    automake \
-    ca-certificates \
-    g++ \
-    git \
-    libapr1-dev \
-    libaprutil1-dev \
-    libcurl4-gnutls-dev \
-    libpcre++-dev \
-    libtool \
-    libxml2-dev \
-    libyajl-dev \
-    lua5.2-dev \
-    make \
-    pkgconf \
-    wget
+ARG MODSEC_VERSION=2.9.5 \
+    SSDEEP_VERSION=2.14.1 \
+    FUZZY_VERSION=2.1.0
 
-RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz \
-    && tar -xzf ssdeep-2.14.1.tar.gz \
-    && cd ssdeep-2.14.1 \
-    && ./configure \
-    && make \
-    && make install \
-    && make clean
+RUN set -eux; \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections; \
+    apt-get update -qq; \
+    apt-get install -y -qq --no-install-recommends --no-install-suggests \
+        automake \
+        ca-certificates \
+        g++ \
+        git \
+        libapr1-dev \
+        libaprutil1-dev \
+        libcurl4-gnutls-dev \
+        libpcre++-dev \
+        libtool \
+        libxml2-dev \
+        libyajl-dev \
+        lua5.2-dev \
+        make \
+        pkgconf \
+        wget
 
-RUN git clone https://github.com/SpiderLabs/ModSecurity --branch v${MODSEC_VERSION} --depth 1 \
-    && cd ModSecurity \
-    && ./autogen.sh \
-    && ./configure \
-    && make \
-    && make install \
-    && make clean
+    RUN set -eux; \
+    wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    tar -xzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    cd ssdeep-${SSDEEP_VERSION}; \
+    ./configure; \
+    make; \
+    make install; \
+    make clean
+
+RUN set -eux; \
+    git clone https://github.com/SpiderLabs/ModSecurity --branch v${MODSEC_VERSION} --depth 1; \
+    cd ModSecurity; \
+    ./autogen.sh; \
+    ./configure; \
+    make; \
+    make install; \
+    make clean
 
 # Generate self-signed certificates (if needed)
 RUN mkdir -p /usr/share/TLS
@@ -45,9 +52,11 @@ RUN openssl req -x509 -days 365 -new \
     -keyout /usr/share/TLS/server.key \
     -out /usr/share/TLS/server.crt
 
-FROM httpd:2.4
+FROM httpd:${APACHE_VERSION}
 
-ARG MODSEC_VERSION=2.9.4
+ARG MODSEC_VERSION=2.9.5 \
+    SSDEEP_VERSION=2.14.1 \
+    FUZZY_VERSION=2.1.0
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 
@@ -101,56 +110,58 @@ ENV ACCESSLOG=/var/log/apache2/access.log \
     TIMEOUT=60 \
     WORKER_CONNECTIONS=400
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-    && apt-get update -qq \
-    && apt-get install -qq -y --no-install-recommends --no-install-suggests \
-    ca-certificates \
-    libcurl3-gnutls \
-    libxml2 \
-    libyajl2 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /etc/modsecurity.d/ \
-    && mkdir -p /tmp/modsecurity/data \
-    && mkdir -p /tmp/modsecurity/upload \
-    && mkdir -p /tmp/modsecurity/tmp \
-    && chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity \
-    && mkdir -p /var/log/apache2/
+RUN set -eux; \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections; \
+    apt-get update -qq; \
+    apt-get install -qq -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        libcurl3-gnutls \
+        libxml2 \
+        libyajl2; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*; \
+    mkdir -p /etc/modsecurity.d/; \
+    mkdir -p /tmp/modsecurity/data; \
+    mkdir -p /tmp/modsecurity/upload; \
+    mkdir -p /tmp/modsecurity/tmp; \
+    chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity; \
+    mkdir -p /var/log/apache2/
 
 COPY --from=build /usr/local/apache2/modules/mod_security2.so                  /usr/local/apache2/modules/mod_security2.so
 COPY --from=build /usr/local/apache2/ModSecurity/modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf
 COPY --from=build /usr/local/apache2/ModSecurity/unicode.mapping               /etc/modsecurity.d/unicode.mapping
-COPY --from=build /usr/local/lib/libfuzzy.so.2.1.0                             /usr/local/lib/libfuzzy.so.2.1.0
+COPY --from=build /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}                  /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}
 COPY --from=build /usr/local/bin/ssdeep                                        /usr/local/bin/ssdeep
 COPY --from=build /usr/share/TLS/server.key                                    /usr/local/apache2/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt                                    /usr/local/apache2/conf/server.crt
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY v2-apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 
-RUN ln -s libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so \
-    && ln -s libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so.2 \
-    && ldconfig
+RUN set -eux; \
+    ln -s libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so; \
+    ln -s libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so.2; \
+    ldconfig
 
-RUN sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|(ServerTokens) Full|\1 Prod|' /usr/local/apache2/conf/extra/httpd-default.conf \
-    && sed -i -E 's|#(ServerName) www.example.com:80|\1 ${SERVER_NAME}|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule unique_id_module)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule rewrite_module modules/mod_rewrite.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule proxy_module modules/mod_proxy.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule proxy_http_module modules/mod_proxy_http.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule remoteip_module modules/mod_remoteip.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule socache_shmcb_module modules/mod_socache_shmcb.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule ssl_module modules/mod_ssl.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule http2_module modules/mod_http2.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-default.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-proxy.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-ssl.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-vhosts.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && echo 'Include conf/extra/httpd-locations.conf' >> /usr/local/apache2/conf/httpd.conf \
-    && echo 'Include conf/extra/httpd-modsecurity.conf' >> /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|(MaxRequestWorkers[ ]*)[0-9]*|\1${WORKER_CONNECTIONS}|' /usr/local/apache2/conf/extra/httpd-mpm.conf
-
-RUN chgrp -R 0 /var/log/ /usr/local/apache2/ \
-    && chmod -R g=u /var/log/ /usr/local/apache2/
+RUN set -eux; \
+    sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|(ServerTokens) Full|\1 Prod|' /usr/local/apache2/conf/extra/httpd-default.conf; \
+    sed -i -E 's|#(ServerName) www.example.com:80|\1 ${SERVER_NAME}|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule unique_id_module)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule rewrite_module modules/mod_rewrite.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule proxy_module modules/mod_proxy.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule proxy_http_module modules/mod_proxy_http.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule remoteip_module modules/mod_remoteip.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule socache_shmcb_module modules/mod_socache_shmcb.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule ssl_module modules/mod_ssl.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule http2_module modules/mod_http2.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-default.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-proxy.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-ssl.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-vhosts.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    echo 'Include conf/extra/httpd-locations.conf' >> /usr/local/apache2/conf/httpd.conf; \
+    echo 'Include conf/extra/httpd-modsecurity.conf' >> /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|(MaxRequestWorkers[ ]*)[0-9]*|\1${WORKER_CONNECTIONS}|' /usr/local/apache2/conf/extra/httpd-mpm.conf; \
+    chgrp -R 0 /var/log/ /usr/local/apache2/; \
+    chmod -R g=u /var/log/ /usr/local/apache2/
 
 # Use httpd-foreground from upstream

--- a/v2-apache/Dockerfile-alpine
+++ b/v2-apache/Dockerfile-alpine
@@ -1,6 +1,10 @@
-FROM httpd:2.4-alpine as build
+ARG APACHE_VERSION=2.4
 
-ARG MODSEC_VERSION=2.9.4
+FROM httpd:${APACHE_VERSION}-alpine as build
+
+ARG MODSEC_VERSION=2.9.5 \
+    SSDEEP_VERSION=2.14.1 \
+    FUZZY_VERSION=2.1.0
 
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN set -eux; \
@@ -34,22 +38,24 @@ RUN set -eux; \
 
 
 # This one is in edge still for Alpine, so just compile
-RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz \
-    && tar -xvzf ssdeep-2.14.1.tar.gz \
-    && cd ssdeep-2.14.1 \
-    && ./configure \
-    && make \
-    && make install \
-    && make clean
+RUN set -eux; \
+    wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    cd ssdeep-${SSDEEP_VERSION}; \
+    ./configure; \
+    make; \
+    make install; \
+    make clean
 
-RUN wget --quiet https://github.com/SpiderLabs/ModSecurity/archive/refs/tags/v${MODSEC_VERSION}.tar.gz \
-    && tar -zxvf v${MODSEC_VERSION}.tar.gz \
-    && cd ModSecurity-${MODSEC_VERSION} \
-    && ./autogen.sh \
-    && ./configure --with-yajl --with-ssdeep --with-lmdb \
-    && make \
-    && make install \
-    && make clean
+RUN set -eux; \
+    wget --quiet https://github.com/SpiderLabs/ModSecurity/archive/refs/tags/v${MODSEC_VERSION}.tar.gz; \
+    tar -zxvf v${MODSEC_VERSION}.tar.gz; \
+    cd ModSecurity-${MODSEC_VERSION}; \
+    ./autogen.sh; \
+    ./configure --with-yajl --with-ssdeep --with-lmdb; \
+    make; \
+    make install; \
+    make clean
 
 # Generate self-signed certificates (if needed)
 RUN mkdir -p /usr/share/TLS
@@ -59,9 +65,11 @@ RUN openssl req -x509 -days 365 -new \
     -keyout /usr/share/TLS/server.key \
     -out /usr/share/TLS/server.crt
 
-FROM httpd:2.4-alpine
+FROM httpd:${APACHE_VERSION}-alpine
 
-ARG MODSEC_VERSION=2.9.4
+ARG MODSEC_VERSION=2.9.5 \
+    SSDEEP_VERSION=2.14.1 \
+    FUZZY_VERSION=2.1.0
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 
@@ -128,39 +136,41 @@ RUN set -eux; \
 COPY --from=build /usr/local/apache2/modules/mod_security2.so                  /usr/local/apache2/modules/mod_security2.so
 COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf
 COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/unicode.mapping               /etc/modsecurity.d/unicode.mapping
-COPY --from=build /usr/local/lib/libfuzzy.so.2.1.0                             /usr/local/lib/libfuzzy.so.2.1.0
+COPY --from=build /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}                             /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}
 COPY --from=build /usr/local/bin/ssdeep                                        /usr/local/bin/ssdeep
 COPY --from=build /usr/share/TLS/server.key                                    /usr/local/apache2/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt                                    /usr/local/apache2/conf/server.crt
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY v2-apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 
-RUN ln -s /usr/local/lib/libfuzzy.so.2.1.0 /usr/local/lib/libfuzzy.so.2 \
-    && sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|(ServerTokens) Full|\1 Prod|' /usr/local/apache2/conf/extra/httpd-default.conf \
-    && sed -i -E 's|#(ServerName) www.example.com:80|\1 ${SERVER_NAME}|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule unique_id_module)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule rewrite_module modules/mod_rewrite.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule proxy_module modules/mod_proxy.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule proxy_http_module modules/mod_proxy_http.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule remoteip_module modules/mod_remoteip.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule socache_shmcb_module modules/mod_socache_shmcb.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule ssl_module modules/mod_ssl.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(LoadModule http2_module modules/mod_http2.so)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-default.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-proxy.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-ssl.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|#(Include conf/extra/httpd-vhosts.conf)|\1|' /usr/local/apache2/conf/httpd.conf \
-    && echo 'Include conf/extra/httpd-locations.conf' >> /usr/local/apache2/conf/httpd.conf \
-    && echo 'Include conf/extra/httpd-modsecurity.conf' >> /usr/local/apache2/conf/httpd.conf \
-    && sed -i -E 's|(MaxRequestWorkers[ ]*)[0-9]*|\1${WORKER_CONNECTIONS}|' /usr/local/apache2/conf/extra/httpd-mpm.conf
+RUN set -eux; \
+    ln -s /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so.2; \
+    sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|(ServerTokens) Full|\1 Prod|' /usr/local/apache2/conf/extra/httpd-default.conf; \
+    sed -i -E 's|#(ServerName) www.example.com:80|\1 ${SERVER_NAME}|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule unique_id_module)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule rewrite_module modules/mod_rewrite.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule proxy_module modules/mod_proxy.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule proxy_http_module modules/mod_proxy_http.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule remoteip_module modules/mod_remoteip.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule socache_shmcb_module modules/mod_socache_shmcb.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule ssl_module modules/mod_ssl.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(LoadModule http2_module modules/mod_http2.so)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-default.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-proxy.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-ssl.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|#(Include conf/extra/httpd-vhosts.conf)|\1|' /usr/local/apache2/conf/httpd.conf; \
+    echo 'Include conf/extra/httpd-locations.conf' >> /usr/local/apache2/conf/httpd.conf; \
+    echo 'Include conf/extra/httpd-modsecurity.conf' >> /usr/local/apache2/conf/httpd.conf; \
+    sed -i -E 's|(MaxRequestWorkers[ ]*)[0-9]*|\1${WORKER_CONNECTIONS}|' /usr/local/apache2/conf/extra/httpd-mpm.conf
 
-RUN mkdir -p /var/log/apache2 \
-    && mkdir -p /tmp/modsecurity/data \
-    && mkdir -p /tmp/modsecurity/upload \
-    && mkdir -p /tmp/modsecurity/tmp \
-    && chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity /var/log/apache2 \
-    && chgrp -R 0 /var/log/ /usr/local/apache2/ \
-    && chmod -R g=u /var/log/ /usr/local/apache2/
+RUN set -eux; \
+    mkdir -p /var/log/apache2; \
+    mkdir -p /tmp/modsecurity/data; \
+    mkdir -p /tmp/modsecurity/upload; \
+    mkdir -p /tmp/modsecurity/tmp; \
+    chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity /var/log/apache2; \
+    chgrp -R 0 /var/log/ /usr/local/apache2/; \
+    chmod -R g=u /var/log/ /usr/local/apache2/
 
 # Use httpd-foreground from upstream

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -1,74 +1,81 @@
-ARG NGINX_VERSION="1.20.1"
+ARG NGINX_VERSION="1.20.2"
 
 FROM nginx:${NGINX_VERSION} as build
 
-ARG MODSEC_VERSION=3.0.5 \
+ARG MODSEC_VERSION=3.0.6 \
     YAJL_VERSION=2.1.0 \
     FUZZY_VERSION=2.1.0 \
+    LMDB_VERSION=0.9.23 \
     SSDEEP_VERSION=2.14.1
 
-RUN apt-get update \
-     && apt-get install -y --no-install-recommends \
-     automake \
-     cmake \
-     doxygen \
-     g++ \
-     git \
-     libcurl4-gnutls-dev \
-     libgeoip-dev \
-     liblua5.3-dev \
-     libpcre++-dev \
-     libtool \
-     libxml2-dev \
-     make \
-     ruby \
-     wget \
-     zlib1g-dev \
-     && apt-get clean \
-     && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        automake \
+        cmake \
+        doxygen \
+        g++ \
+        git \
+        libcurl4-gnutls-dev \
+        libgeoip-dev \
+        liblua5.3-dev \
+        libpcre++-dev \
+        libtool \
+        libxml2-dev \
+        make \
+        ruby \
+        wget \
+        zlib1g-dev; \
+     apt-get clean; \
+     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /sources
 
-RUN git clone https://github.com/LMDB/lmdb --branch LMDB_0.9.23 --depth 1 \
-     && make -C lmdb/libraries/liblmdb install \
-     && strip /usr/local/lib/liblmdb*.so*
+RUN set -eux; \
+    git clone https://github.com/LMDB/lmdb --branch LMDB_${LMDB_VERSION} --depth 1; \
+    make -C lmdb/libraries/liblmdb install; \
+    strip /usr/local/lib/liblmdb*.so*
 
-RUN git clone https://github.com/lloyd/yajl --branch ${YAJL_VERSION} --depth 1 \
-     && cd yajl \
-     && ./configure \
-     && make install \
-     && strip /usr/local/lib/libyajl*.so*
+RUN set -eux; \
+    git clone https://github.com/lloyd/yajl --branch ${YAJL_VERSION} --depth 1; \
+    cd yajl; \
+    ./configure; \
+    make install; \
+    strip /usr/local/lib/libyajl*.so*
 
-RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz \
-     && tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz \
-     && cd ssdeep-${SSDEEP_VERSION} \
-     && ./configure \
-     && make install \
-     && strip /usr/local/lib/libfuzzy*.so*
+RUN set -eux; \
+    wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    cd ssdeep-${SSDEEP_VERSION}; \
+    ./configure; \
+    make install; \
+    strip /usr/local/lib/libfuzzy*.so*
 
-RUN git clone https://github.com/SpiderLabs/ModSecurity --branch v${MODSEC_VERSION} --depth 1 \
-     && cd ModSecurity \
-     && ./build.sh \
-     && git submodule init \
-     && git submodule update \
-     && ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ \
-     && make install \
-     && strip /usr/local/modsecurity/lib/lib*.so*
+RUN set -eux; \
+    git clone https://github.com/SpiderLabs/ModSecurity --branch v${MODSEC_VERSION} --depth 1; \
+    cd ModSecurity; \
+    ./build.sh; \
+    git submodule init; \
+    git submodule update; \
+    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/; \
+    make install; \
+    strip /usr/local/modsecurity/lib/lib*.so*
 
 # We use master
-RUN git clone -b master --depth 1 https://github.com/SpiderLabs/ModSecurity-nginx.git \
-     && wget --quiet http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
-     && tar -xzf nginx-${NGINX_VERSION}.tar.gz \
-     && cd ./nginx-${NGINX_VERSION} \
-     && ./configure --with-compat --add-dynamic-module=../ModSecurity-nginx \
-     && make modules \
-     && strip objs/ngx_http_modsecurity_module.so \
-     && cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules/ \
-     && mkdir /etc/modsecurity.d \
-     && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended \
-     -O /etc/modsecurity.d/modsecurity.conf \
-     && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping \
-     -O /etc/modsecurity.d/unicode.mapping
+RUN set -eux; \
+    git clone -b master --depth 1 https://github.com/SpiderLabs/ModSecurity-nginx.git; \
+    wget --quiet http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz; \
+    tar -xzf nginx-${NGINX_VERSION}.tar.gz; \
+    cd ./nginx-${NGINX_VERSION}; \
+    ./configure --with-compat --add-dynamic-module=../ModSecurity-nginx; \
+    make modules; \
+    strip objs/ngx_http_modsecurity_module.so; \
+    cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules/; \
+    mkdir /etc/modsecurity.d; \
+    wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended \
+         -O /etc/modsecurity.d/modsecurity.conf; \
+    wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping \
+         -O /etc/modsecurity.d/unicode.mapping
 
 # Generate self-signed certificates (if needed)
 RUN mkdir -p /usr/share/TLS
@@ -80,15 +87,13 @@ RUN openssl req -x509 -days 365 -new \
 
 FROM nginx:${NGINX_VERSION}
 
-ARG MODSEC_VERSION=3.0.5 \
+ARG MODSEC_VERSION=3.0.6 \
     YAJL_VERSION=2.1.0 \
     FUZZY_VERSION=2.1.0 \
+    LMDB_VERSION=0.9.23 \
     SSDEEP_VERSION=2.14.1
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
-
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV ACCESSLOG=/var/log/nginx/access.log \
      BACKEND=http://localhost:80 \
@@ -131,19 +136,22 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
      WORKER_CONNECTIONS=1024 \
      LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
 
-RUN apt-get update \
-     && apt-get install -y --no-install-recommends \
-     ca-certificates \
-     libcurl4-gnutls-dev \
-     liblua5.3 \
-     libxml2 \
-     moreutils \
-     && rm -rf /var/lib/apt/lists/* \
-     && apt-get clean \
-     && mkdir /etc/nginx/ssl \
-     && mkdir -p /tmp/modsecurity/{data,upload,tmp} \
-     && mkdir -p /usr/local/modsecurity \
-     && chown -R nginx:nginx /tmp/modsecurity
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libcurl4-gnutls-dev \
+        liblua5.3 \
+        libxml2 \
+        moreutils; \
+    rm -rf /var/lib/apt/lists/*; \
+    apt-get clean; \
+    mkdir /etc/nginx/ssl; \
+    mkdir -p /tmp/modsecurity/data; \
+    mkdir -p /tmp/modsecurity/upload; \
+    mkdir -p /tmp/modsecurity/tmp; \
+    mkdir -p /usr/local/modsecurity; \
+    chown -R nginx:nginx /tmp/modsecurity
 
 COPY --from=build /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/
 COPY --from=build /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/
@@ -172,3 +180,4 @@ RUN set -eux; \
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]
+

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION="1.20.1"
+ARG NGINX_VERSION="1.20.2"
 
 FROM nginx:${NGINX_VERSION}-alpine as build
 
@@ -8,58 +8,61 @@ ARG MODSEC_VERSION=3.0.5 \
 
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \
-    autoconf \
-    automake \
-    ca-certificates \
-    coreutils \        
-    curl-dev \
-    g++ \
-    gcc \
-    geoip-dev \
-    git \
-    libc-dev \
-    libmaxminddb-dev \
-    libstdc++ \
-    libtool \
-    libxml2-dev \
-    linux-headers \
-    lmdb-dev \
-    make \
-    openssl \
-    openssl-dev \
-    pcre-dev \
-    yajl-dev \
-    zlib-dev
+        autoconf \
+        automake \
+        ca-certificates \
+        coreutils \        
+        curl-dev \
+        g++ \
+        gcc \
+        geoip-dev \
+        git \
+        libc-dev \
+        libmaxminddb-dev \
+        libstdc++ \
+        libtool \
+        libxml2-dev \
+        linux-headers \
+        lmdb-dev \
+        make \
+        openssl \
+        openssl-dev \
+        pcre-dev \
+        yajl-dev \
+        zlib-dev
 
 WORKDIR /sources
 
-RUN wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz \
-    && tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz \
-    && cd ssdeep-${SSDEEP_VERSION} \
-    && ./configure \
-    && make install
+RUN set -eux; \
+    wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
+    cd ssdeep-${SSDEEP_VERSION}; \
+    ./configure; \
+    make install
 
-RUN git clone https://github.com/SpiderLabs/ModSecurity --branch v"$MODSEC_VERSION" --depth 1 \
-    && cd ModSecurity \
-    && ./build.sh \
-    && git submodule init \
-    && git submodule update \
-    && ./configure --with-yajl --with-ssdeep --with-lmdb \
-    && make install
+RUN set -eux; \
+    git clone https://github.com/SpiderLabs/ModSecurity --branch v"$MODSEC_VERSION" --depth 1; \
+    cd ModSecurity; \
+    ./build.sh;\
+    git submodule init; \
+    git submodule update; \
+    ./configure --with-yajl --with-ssdeep --with-lmdb; \
+    make install
 
 # We use master
-RUN git clone -b master --depth 1 https://github.com/SpiderLabs/ModSecurity-nginx.git \
-    && wget --quiet http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
-    && tar -xzf nginx-${NGINX_VERSION}.tar.gz \
-    && cd ./nginx-${NGINX_VERSION} \
-    && ./configure --with-compat --add-dynamic-module=../ModSecurity-nginx \
-    && make modules \
-    && cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules/ \
-    && mkdir /etc/modsecurity.d \
-    && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended \
-    -O /etc/modsecurity.d/modsecurity.conf \
-    && wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping \
-    -O /etc/modsecurity.d/unicode.mapping
+RUN set -eux; \
+    git clone -b master --depth 1 https://github.com/SpiderLabs/ModSecurity-nginx.git; \
+    wget --quiet http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz; \
+    tar -xzf nginx-${NGINX_VERSION}.tar.gz; \
+    cd ./nginx-${NGINX_VERSION}; \
+    ./configure --with-compat --add-dynamic-module=../ModSecurity-nginx; \
+    make modules; \
+    cp objs/ngx_http_modsecurity_module.so /etc/nginx/modules/; \
+    mkdir /etc/modsecurity.d; \
+    wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/modsecurity.conf-recommended \
+        -O /etc/modsecurity.d/modsecurity.conf; \
+    wget --quiet https://raw.githubusercontent.com/SpiderLabs/ModSecurity/v3/master/unicode.mapping \
+        -O /etc/modsecurity.d/unicode.mapping
 
 # Generate self-signed certificates (if needed)
 RUN mkdir -p /usr/share/TLS
@@ -120,19 +123,20 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
     WORKER_CONNECTIONS=1024 \
     LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib
 
-RUN apk add --no-cache \
-    curl-dev \
-    libmaxminddb-dev \
-    libstdc++ \
-    libxml2-dev \
-    lmdb-dev \
-    moreutils \
-    tzdata \
-    yajl && \
-    mkdir /etc/nginx/ssl/ && \
-    mkdir -p /tmp/modsecurity/data && \
-    mkdir -p /tmp/modsecurity/upload && \
-    mkdir -p /tmp/modsecurity/tmp && \
+RUN set -eux; \
+    apk add --no-cache \
+        curl-dev \
+        libmaxminddb-dev \
+        libstdc++ \
+        libxml2-dev \
+        lmdb-dev \
+        moreutils \
+        tzdata \
+        yajl; \
+    mkdir /etc/nginx/ssl/; \
+    mkdir -p /tmp/modsecurity/data; \
+    mkdir -p /tmp/modsecurity/upload; \
+    mkdir -p /tmp/modsecurity/tmp; \
     chown -R nginx:nginx /usr/share/nginx /tmp/modsecurity
 
 COPY --from=build /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- Fixes CVE by updating modsecurity
- Moves arguments to top of Dockerfile, so they are listed once
- Uses set -eux everywhere