### PR TITLE
fix: adjust resolver entrypoint to not make the container fail when nginx.conf is read-only

### DIFF
--- a/v3-nginx/docker-entrypoint.d/91-update-resolver.sh
+++ b/v3-nginx/docker-entrypoint.d/91-update-resolver.sh
@@ -7,6 +7,8 @@ LC_ALL=C
 ME=$( basename "$0" )
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: unable to modify DNS_SERVER in /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
 DNS_SERVER="${DNS_SERVER:-$(grep -i '^nameserver' /etc/resolv.conf | head -n1 | cut -d ' ' -f2)}"
 
 sed -i.bak -r 's/DNS_SERVER/'"${DNS_SERVER}"'/' /etc/nginx/nginx.conf


### PR DESCRIPTION
This fixes #113