### PR TITLE
fix: use `$realip_remote_addr` in nginx log format

### DIFF
--- a/v3-nginx/templates/conf.d/logging.conf.template
+++ b/v3-nginx/templates/conf.d/logging.conf.template
@@ -1,4 +1,4 @@
-log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+log_format main '$realip_remote_addr - $remote_user [$time_local] "$request" '
                 '$status $body_bytes_sent "$http_referer" '
                 '"$http_user_agent" "$http_x_forwarded_for"';
 


### PR DESCRIPTION
Since we use the real_ip module we also need to use the correct variable
to log the remote addr.

Fixes #129 