### PR TITLE
feat(ci): use unique tags when pushing to hub

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "0 12 * * MON" # Run every Monday
 
 jobs:
   build:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,17 +4,23 @@ on:
     branches:
       - master
 
+env:
+  REPO: "owasp/modsecurity"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - apache
-          - nginx
-        variant:
-          - ""
-          - "-alpine"
+        image: ["apache", "nginx"]
+        variant: ["", "-alpine"]
+        include:
+          - image: apache
+            modsec_version: "2.9.6"
+          - image: nginx
+            modsec_version: "3.0.8"
+        platform:
+          - linux/amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,9 +43,27 @@ jobs:
           username: ${{ secrets.dockerhub_user }}
           password: ${{ secrets.dockerhub_token }}
 
+      - name: Docker meta ${{ matrix.image }}${{ matrix.variant }} - ${{ matrix.modsec_version }}
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REPO }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.image }}${{ matrix.variant }}
+            type=semver,pattern={{major}},value=v${{ matrix.modsec_version }},suffix=-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ matrix.modsec_version }},suffix=-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{version}},value=v${{ matrix.modsec_version }},suffix=-{{date 'YYYYMMDDHHMM'}}
+
       - name: Build and push ${{ matrix.image }}${{ matrix.variant }}
         uses: docker/bake-action@v2.2.0
         with:
-          targets: ${{ matrix.image }}${{ matrix.variant }}
-          files: docker-bake.hcl
+          targets: ${{ matrix.image }}${{ matrix.variant }} - ${{ matrix.modsec_version }}
+          set: |
+            "${{ matrix.image }}${{ matrix.variant }}.args.MODSEC_VERSION=${{ matrix.modsec_version }}"
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
           push: true

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -3,19 +3,22 @@ on:
   pull_request:
     branches:
       - master
+
+env:
+  REPO: "owasp/modsecurity"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - apache
-          - nginx
-        variant:
-          - ""
-          - "-alpine"
-        # Verification can only be done using one platform.
-        # This is a limitation on buildx
+        image: ["apache", "nginx"]
+        variant: ["", "-alpine"]
+        include:
+          - image: apache
+            modsec_version: "2.9.6"
+          - image: nginx
+            modsec_version: "3.0.8"
         platform:
           - linux/amd64
     steps:
@@ -34,26 +37,36 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:master
 
-      - name: Docker meta
-        uses: docker/metadata-action@v4
+      - name: Docker meta ${{ matrix.image }}${{ matrix.variant }} - ${{ matrix.modsec_version }}"
         id: meta
+        uses: docker/metadata-action@v4
         with:
-          images: owasp/modsecurity
-
+          images: |
+            ${{ env.REPO }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.image }}${{ matrix.variant }}
+            type=semver,pattern={{major}},value=v${{ matrix.modsec_version }},suffix=-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ matrix.modsec_version }},suffix=-{{date 'YYYYMMDDHHMM'}}
+            type=semver,pattern={{version}},value=v${{ matrix.modsec_version }},suffix=-{{date 'YYYYMMDDHHMM'}}
+        
       - name: Build ${{ matrix.image }}${{ matrix.variant }} - ${{ matrix.platform }}
         uses: docker/bake-action@v2.2.0
         with:
-          files: docker-bake.hcl
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
           targets: ${{ matrix.image }}${{ matrix.variant }}
           set: |
             "${{ matrix.image }}${{ matrix.variant }}.platform=${{ matrix.platform }}"
+            "${{ matrix.image }}${{ matrix.variant }}.args.MODSEC_VERSION=${{ matrix.modsec_version }}"
           pull: true
           load: true
 
       - name: Run ${{ matrix.image }}${{ matrix.variant }}
         run: |
-          TAG=$(docker buildx bake -f docker-bake.hcl --print | jq -r '.target["${{ matrix.image }}${{ matrix.variant }}"].tags[2]')
-          docker run -d --name ${{ matrix.image }}${{ matrix.variant }}-test "${TAG}"
+          docker run -d --name ${{ matrix.image }}${{ matrix.variant }}-test "${{ env.REPO }}:${{ matrix.image }}${{ matrix.variant }}"
           docker logs ${{ matrix.image }}${{ matrix.variant }}-test
 
       - name: Verify ${{ matrix.image }}${{ matrix.variant }}

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -46,15 +46,16 @@ jobs:
           files: docker-bake.hcl
           targets: ${{ matrix.image }}${{ matrix.variant }}
           set: |
-            "${{ matrix.image }}${{ matrix.variant }}.tags=${{ matrix.image }}${{ matrix.variant }}-test"
             "${{ matrix.image }}${{ matrix.variant }}.platform=${{ matrix.platform }}"
           pull: true
           load: true
 
       - name: Run ${{ matrix.image }}${{ matrix.variant }}
         run: |
-          docker run -d --name ${{ matrix.image }}${{ matrix.variant }}-test ${{ matrix.image }}${{ matrix.variant }}-test
+          TAG=$(docker buildx bake -f docker-bake.hcl --print | jq -r '.target["${{ matrix.image }}${{ matrix.variant }}"].tags[2]')
+          docker run -d --name ${{ matrix.image }}${{ matrix.variant }}-test "${TAG}"
           docker logs ${{ matrix.image }}${{ matrix.variant }}-test
+
       - name: Verify ${{ matrix.image }}${{ matrix.variant }}
         run: |
           docker logs ${{ matrix.image }}${{ matrix.variant }}-test

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:master
 
-      - name: Docker meta ${{ matrix.image }}${{ matrix.variant }} - ${{ matrix.modsec_version }}"
+      - name: Docker meta ${{ matrix.image }}${{ matrix.variant }} - ${{ matrix.modsec_version }}
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -66,7 +66,9 @@ jobs:
 
       - name: Run ${{ matrix.image }}${{ matrix.variant }}
         run: |
-          docker run -d --name ${{ matrix.image }}${{ matrix.variant }}-test "${{ env.REPO }}:${{ matrix.image }}${{ matrix.variant }}"
+          TAG=$(docker image inspect -f '{{ json .RepoTags }}' ${{ env.REPO }}:${{ matrix.image }}${{ matrix.variant }} | jq -r '.[0]')
+          echo "Starting container with TAG=$TAG"
+          docker run --pull "never" -d --name ${{ matrix.image }}${{ matrix.variant }}-test "$TAG"
           docker logs ${{ matrix.image }}${{ matrix.variant }}-test
 
       - name: Verify ${{ matrix.image }}${{ matrix.variant }}

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ $ docker buildx use $(docker buildx create --platform linux/amd64,linux/arm64,li
 $ docker buildx bake -f docker-bake.hcl
 ```
 
-We require a version of buildx >= v0.9.1. You can check which version you have using:
+We require a version of `buildx` >= v0.9.1. [Visit the official documentation](https://docs.docker.com/build/buildx/install/) for instructions on installing and upgrading `buildx`. You can check which version you have using:
 ```
-❯ docker buildx version
+docker buildx version
 github.com/docker/buildx v0.9.1 ed00243a0ce2a0aee75311b06e32d33b44729689
 ```
 
@@ -51,7 +51,7 @@ We are building now for these architectures:
   - linux/arm64
   - linux/arm/v7
 
-For additional settings, you can check this repository github actions to see its usage.
+You can find additional examples on how to use `buildx` in this repository's GitHub actions.
 
 ## Quick reference
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * `3-YYYYMMDDHHMM`, `3.0-YYYYMMDDHHMM`, `3.0.8-YYYYMMDDHHMM`, `nginx` ([master/v3-nginx/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.20 official stable base image*
 * `2-YYYYMMDDHHMM`, `2.9-YYYYMMDDHHMM`, `2.9.6-YYYYMMDDHHMM`, `apache` ([master/v2-apache/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile)) – *last stable ModSecurity v2 on Apache 2.4 official stable base image*
 
-⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx` or `owasp/modsecurity/apache`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209` or `owasp/modsecurity:2.9.6-alpine-202209141209` for example. You have been warned.
+⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx` or `owasp/modsecurity:apache`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209` or `owasp/modsecurity:2.9.6-alpine-202209141209` for example. You have been warned.
 
 ## Supported variants
 
@@ -21,7 +21,7 @@ We have support for [alpine linux](https://www.alpinelinux.org/) variants of the
 * `3-alpine-YYYYMMDDHHMM`, `3.0-alpine-YYYYMMDDHHMM`, `3.0.8-alpine-YYYYMMDDHHMM`, `nginx-alpine` ([master/v3-nginx/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile-alpine) – *last stable ModSecurity v3 on Nginx 1.20 Alpine official stable base image*
 * `2-alpine-YYYYMMDDHHMM`, `2.9-alpine-YYYYMMDDHHMM`, `2.9.6-alpine-YYYYMMDDHHMM`, `apache-alpine` ([master/v2-apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 Alpine official stable base image*
 
-⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx-alpine` or `owasp/modsecurity/apache-alpine`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209-alpine` or `owasp/modsecurity:2.9.6-202209141209` for example. You have been warned.
+⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx-alpine` or `owasp/modsecurity:apache-alpine`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209-alpine` or `owasp/modsecurity:2.9.6-202209141209` for example. You have been warned.
 
 ## Supported architectures
 
@@ -34,11 +34,24 @@ $ docker buildx use $(docker buildx create --platform linux/amd64,linux/arm64,li
 $ docker buildx bake -f docker-bake.hcl
 ```
 
+We require a version of buildx >= v0.9.1. You can check which version you have using:
+```
+❯ docker buildx version
+github.com/docker/buildx v0.9.1 ed00243a0ce2a0aee75311b06e32d33b44729689
+```
+
+If you want to see the targets of the build, use:
+```
+docker buildx bake -f ./docker-bake.hcl --print
+```
+
 We are building now for these architectures:
   - linux/amd64
   - linux/i386
   - linux/arm64
   - linux/arm/v7
+
+For additional settings, you can check this repository github actions to see its usage.
 
 ## Quick reference
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@
 
 ## Supported tags and respective `Dockerfile` links
 
-* `3`, `3.0`, `3.0.8`, `nginx` ([master/v3-nginx/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.20 official stable base image*
-* `2`, `2.9`, `2.9.6`, `apache` ([master/v2-apache/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile)) – *last stable ModSecurity v2 on Apache 2.4 official stable base image*
+* `3-YYYYMMDDHHMM`, `3.0-YYYYMMDDHHMM`, `3.0.8-YYYYMMDDHHMM`, `nginx` ([master/v3-nginx/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile)) – *last stable ModSecurity v3 on Nginx 1.20 official stable base image*
+* `2-YYYYMMDDHHMM`, `2.9-YYYYMMDDHHMM`, `2.9.6-YYYYMMDDHHMM`, `apache` ([master/v2-apache/Dockerfile](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile)) – *last stable ModSecurity v2 on Apache 2.4 official stable base image*
+
+⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx` or `owasp/modsecurity/apache`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209` or `owasp/modsecurity:2.9.6-alpine-202209141209` for example. You have been warned.
 
 ## Supported variants
 
 We have support for [alpine linux](https://www.alpinelinux.org/) variants of the base images. Just add `-alpine` and you will get it. Examples:
 
-* `3-alpine`, `3.0-alpine`, `3.0.8-alpine`, `nginx-alpine` ([master/v3-nginx/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile-alpine) – *last stable ModSecurity v3 on Nginx 1.20 Alpine official stable base image*
-* `2-alpine`, `2.9-alpine`, `2.9.6-alpine`, `apache-alpine` ([master/v2-apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 Alpine official stable base image*
+* `3-alpine-YYYYMMDDHHMM`, `3.0-alpine-YYYYMMDDHHMM`, `3.0.8-alpine-YYYYMMDDHHMM`, `nginx-alpine` ([master/v3-nginx/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v3-nginx/Dockerfile-alpine) – *last stable ModSecurity v3 on Nginx 1.20 Alpine official stable base image*
+* `2-alpine-YYYYMMDDHHMM`, `2.9-alpine-YYYYMMDDHHMM`, `2.9.6-alpine-YYYYMMDDHHMM`, `apache-alpine` ([master/v2-apache/Dockerfile-alpine](https://github.com/coreruleset/modsecurity-docker/blob/master/v2-apache/Dockerfile-alpine)) – *last stable ModSecurity v2 on Apache 2.4 Alpine official stable base image*
+
+⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx-alpine` or `owasp/modsecurity/apache-alpine`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209-alpine` or `owasp/modsecurity:2.9.6-202209141209` for example. You have been warned.
 
 ## Supported architectures
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -76,7 +76,7 @@ target "apache" {
 target "apache-alpine" {
     inherits = ["build"]
     dockerfile="v2-apache/Dockerfile-alpine"
-    tags = concat(tag("apache"),
+    tags = concat(tag("apache-alpine"),
         vtag("${apache_modsec_version}", "-alpine")
     )
     args = {
@@ -98,7 +98,7 @@ target "nginx" {
 target "nginx-alpine" {
     inherits = ["build"]
     dockerfile="v3-nginx/Dockerfile-alpine"
-    tags = concat(tag("nginx"),
+    tags = concat(tag("nginx-alpine"),
         vtag("${nginx_modsec_version}", "-alpine")
     )
     args = {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,7 +20,7 @@ function "minor" {
     params = [version]
     result = join(".", slice(split(".", version),0,2))
 }
-# result = split(version, ".")[0] + "." + split(version, ".")[1] "." + split(version, ".")[2]
+
 function "patch" {
     params = [version]
     result = join(".", slice(split(".", version),0,3))
@@ -40,11 +40,6 @@ function "vtag" {
     )
 }
 
-// function "tag" {
-//   params = [tag]
-//   result = ["${REPO}:${tag}"]
-// }
-
 group "default" {
     targets = [
         "apache",
@@ -54,20 +49,32 @@ group "default" {
     ]
 }
 
+target "docker-metadata-action" {}
+
+target "build" {
+  inherits = ["docker-metadata-action"]
+  context = "./"
+  platforms = [
+    "linux/amd64", 
+    "linux/arm64/v8", 
+    "linux/arm/v7", 
+    "linux/i386"
+  ]
+}
+
 target "apache" {
-    context="."
+    inherits = ["build"]
     dockerfile="v2-apache/Dockerfile"
     tags = concat(tag("apache"),
         vtag("${apache_modsec_version}", "")
     )
-    platforms = ["linux/amd64", "linux/arm64/v8", "linux/arm/v7", "linux/i386"]
     args = {
         MODSEC_VERSION = "${apache_modsec_version}"
     }
 }
 
 target "apache-alpine" {
-    context="."    
+    inherits = ["build"]
     dockerfile="v2-apache/Dockerfile-alpine"
     tags = concat(tag("apache"),
         vtag("${apache_modsec_version}", "-alpine")
@@ -78,7 +85,7 @@ target "apache-alpine" {
 }
 
 target "nginx" {
-    context="."    
+    inherits = ["build"]  
     dockerfile="v3-nginx/Dockerfile"
     tags = concat(tag("nginx"),
         vtag("${nginx_modsec_version}", "")
@@ -89,7 +96,7 @@ target "nginx" {
 }
 
 target "nginx-alpine" {
-    context="."    
+    inherits = ["build"]
     dockerfile="v3-nginx/Dockerfile-alpine"
     tags = concat(tag("nginx"),
         vtag("${nginx_modsec_version}", "-alpine")

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -9,8 +9,9 @@ ARG MODSEC_VERSION=3.0.8 \
     SSDEEP_VERSION=2.14.1
 
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections; \
+    apt-get update -qq; \
+    LD_LIBRARY_PATH="" apt-get install -y -qq --no-install-recommends --no-install-suggests \
         automake \
         cmake \
         doxygen \
@@ -158,8 +159,9 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
     NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
 
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections; \
+    apt-get update -qq; \
+    LD_LIBRARY_PATH="" apt-get install -y -qq --no-install-recommends --no-install-suggests \
         ca-certificates \
         libcurl4-gnutls-dev \
         liblua5.3 \


### PR DESCRIPTION
- tags are based on build date using YYYYMMDDHHMM
- main label does not change, only specific ones
- remove cron build to use dispatched builds or merges only

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>