### PR TITLE
feat(health): add health check

### DIFF
--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -75,6 +75,24 @@ jobs:
         run: |
           docker logs "${{ matrix.image }}${{ matrix.variant }}-test"
           [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{.State.Running}}') = 'true' ]
-          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health.Status}}') = 'starting' ]
-          sleep 30
-          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health.Status}}') = 'healthy' ]
+          while true
+          do
+            STATUS=$(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{.State.Health.Status}}')
+            case ${STATUS} in
+              healthy)
+                echo "$(date -u) Healthy!!!"
+                sleep 1
+                exit 0;;
+              unhealthy)
+                echo "$(date -u) Unhealthy!!!"
+                sleep 1
+                exit 9;;
+              starting)
+                echo "$(date -u) starting!!!";;
+              *) 
+                echo "Huh? ${STATUS}"
+                sleep 1
+                exit 10;;
+            esac
+            sleep 1
+          done

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -75,3 +75,6 @@ jobs:
         run: |
           docker logs "${{ matrix.image }}${{ matrix.variant }}-test"
           [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{.State.Running}}') = 'true' ]
+          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health}}') | jq -r '.Status' = 'starting' ]
+          sleep 30
+          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health}}') | jq -r '.Status' = 'healthy' ]

--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -75,6 +75,6 @@ jobs:
         run: |
           docker logs "${{ matrix.image }}${{ matrix.variant }}-test"
           [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{.State.Running}}') = 'true' ]
-          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health}}') | jq -r '.Status' = 'starting' ]
+          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health.Status}}') = 'starting' ]
           sleep 30
-          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health}}') | jq -r '.Status' = 'healthy' ]
+          [ $(docker inspect ${{ matrix.image }}${{ matrix.variant }}-test --format='{{json .State.Health.Status}}') = 'healthy' ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 ⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx` or `owasp/modsecurity:apache`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209` or `owasp/modsecurity:2.9.6-alpine-202209141209` for example. You have been warned.
 
+🆕 We added a health checking to the images. Containers already return HTTP status code 200 when accesing the `/healthz` URI. When a container has a healthcheck specified, it has a health status in addition to its normal status. This status is initially starting. Whenever a health check passes, it becomes healthy (whatever state it was previously in). After a certain number of consecutive failures, it becomes unhealthy. See https://docs.docker.com/engine/reference/builder/#healthcheck for more information.
+
 ## Supported variants
 
 We have support for [alpine linux](https://www.alpinelinux.org/) variants of the base images. Just add `-alpine` and you will get it. Examples:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ⚠️ We changed tags to [support production usage](https://github.com/coreruleset/modsecurity-crs-docker/issues/67). Now, if you want to use the "rolling version", use the tag `owasp/modsecurity:nginx` or `owasp/modsecurity:apache`. If you need a stable long term image, use the one with the build date in `YYYYMMDDHHMM` format, example `owasp/modsecurity:3-202209141209` or `owasp/modsecurity:2.9.6-alpine-202209141209` for example. You have been warned.
 
-🆕 We added a health checking to the images. Containers already return HTTP status code 200 when accesing the `/healthz` URI. When a container has a healthcheck specified, it has a health status in addition to its normal status. This status is initially starting. Whenever a health check passes, it becomes healthy (whatever state it was previously in). After a certain number of consecutive failures, it becomes unhealthy. See https://docs.docker.com/engine/reference/builder/#healthcheck for more information.
+🆕 We added healthchecks to the images. Containers already return HTTP status code 200 when accessing the `/healthz` URI. When a container has a healthcheck specified, it has a _health status_ in addition to its normal status. This status is initially `starting`. Whenever a health check passes, it becomes `healthy` (whatever state it was previously in). After a certain number of consecutive failures, it becomes `unhealthy`. See https://docs.docker.com/engine/reference/builder/#healthcheck for more information.
 
 ## Supported variants
 

--- a/src/bin/healthcheck
+++ b/src/bin/healthcheck
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Health Check running web server.
+# Endpoint /healthz should always return 200.
+
+scheme="https"
+host="localhost"
+port="${SSL_PORT}"
+
+if [ "$(env | grep -c APACHE)" -gt 1 ] && [ "${SSL_ENGINE}" = "off" ]
+then 
+    scheme="http"
+    port="${PORT}"
+fi
+
+curl -sk "${scheme}://${host}:${port}/healthz"

--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -120,6 +120,7 @@ RUN set -eux; \
     apt-get update -qq; \
     apt-get install -qq -y --no-install-recommends --no-install-suggests \
         ca-certificates \
+        curl \
         libcurl3-gnutls \
         libfuzzy2 \
         libxml2 \
@@ -139,6 +140,7 @@ COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/unicode.mappi
 COPY --from=build /usr/share/TLS/server.key                                    /usr/local/apache2/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt                                    /usr/local/apache2/conf/server.crt
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
+COPY src/bin/healthcheck /usr/local/bin/healthcheck
 COPY v2-apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 
 RUN set -eux; \
@@ -166,5 +168,7 @@ RUN set -eux; \
     sed -i -E 's|(MaxRequestWorkers[ ]*)[0-9]*|\1${WORKER_CONNECTIONS}|' /usr/local/apache2/conf/extra/httpd-mpm.conf; \
     chgrp -R 0 /var/log/ /usr/local/apache2/; \
     chmod -R g=u /var/log/ /usr/local/apache2/
+
+HEALTHCHECK CMD /usr/local/bin/healthcheck
 
 # Use httpd-foreground from upstream

--- a/v2-apache/Dockerfile-alpine
+++ b/v2-apache/Dockerfile-alpine
@@ -128,6 +128,7 @@ ENV APACHE_ALWAYS_TLS_REDIRECT=off \
 RUN set -eux; \
     apk add --no-cache \
     ca-certificates \
+    curl \
     libfuzzy2 \
     libxml2 \
     moreutils \
@@ -140,6 +141,7 @@ COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/unicode.mappi
 COPY --from=build /usr/share/TLS/server.key                                    /usr/local/apache2/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt                                    /usr/local/apache2/conf/server.crt
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
+COPY src/bin/healthcheck /usr/local/bin/healthcheck
 COPY v2-apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 
 RUN set -eux; \
@@ -174,5 +176,7 @@ RUN set -eux; \
     chown -R $(awk '/^User/ { print $2;}' /usr/local/apache2/conf/httpd.conf) /tmp/modsecurity /var/log/apache2; \
     chgrp -R 0 /var/log/ /usr/local/apache2/; \
     chmod -R g=u /var/log/ /usr/local/apache2/
+
+HEALTHCHECK CMD /usr/local/bin/healthcheck
 
 # Use httpd-foreground from upstream

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -147,6 +147,7 @@ RUN set -eux; \
     apt-get update -qq; \
     LD_LIBRARY_PATH="" apt-get install -y -qq --no-install-recommends --no-install-suggests \
         ca-certificates \
+        curl \
         libcurl4-gnutls-dev \
         libfuzzy2 \
         liblua5.3 \
@@ -173,6 +174,7 @@ COPY --from=build /etc/modsecurity.d/modsecurity.conf /etc/modsecurity.d/modsecu
 COPY v3-nginx/templates /etc/nginx/templates/
 COPY src/etc/modsecurity.d/modsecurity-override.conf /etc/nginx/templates/modsecurity.d/modsecurity-override.conf.template
 COPY src/etc/modsecurity.d/setup.conf /etc/nginx/templates/modsecurity.d/setup.conf.template
+COPY src/bin/healthcheck /usr/local/bin/healthcheck
 COPY v3-nginx/docker-entrypoint.d/*.sh /docker-entrypoint.d/
 
 # Comment out the SecDisableBackendCompression option since it is not supported in V3
@@ -184,3 +186,5 @@ RUN set -eux; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so; \
     chgrp -R 0 /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/; \
     chmod -R g=u /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/
+
+HEALTHCHECK CMD /usr/local/bin/healthcheck

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -139,6 +139,7 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
 
 RUN set -eux; \
     apk add --no-cache \
+        curl \
         curl-dev \
         libfuzzy2 \
         libmaxminddb-dev \
@@ -166,6 +167,7 @@ COPY --from=build /etc/modsecurity.d/modsecurity.conf /etc/modsecurity.d/modsecu
 COPY v3-nginx/templates /etc/nginx/templates/
 COPY src/etc/modsecurity.d/modsecurity-override.conf /etc/nginx/templates/modsecurity.d/modsecurity-override.conf.template
 COPY src/etc/modsecurity.d/setup.conf /etc/nginx/templates/modsecurity.d/setup.conf.template
+COPY src/bin/healthcheck /usr/local/bin/healthcheck
 COPY v3-nginx/docker-entrypoint.d/*.sh /docker-entrypoint.d/
 
 # Comment out the SecDisableBackendCompression option since it is not supported in V3
@@ -179,3 +181,5 @@ RUN set -eux; \
     chmod -R g=u /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/
 
 WORKDIR /usr/share/nginx/html
+
+HEALTHCHECK CMD /usr/local/bin/healthcheck


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Adds health check to the `/healtz` endpoint configured in all containers.

Fixes #136.

Note: I did try adding variables to the different times, but docker doesn't like it. :( My idea was to add 4 new variables `HEALTHCHECK_`, but looks like we can't.

```
❯ docker-compose build apache-waf
[+] Building 0.1s (2/2) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                             0.0s
 => => transferring dockerfile: 9.17kB                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                  0.0s
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: dockerfile parse error line 190: time: invalid duration "${HEALTHCHECK_INTERVAL}"
```