### PR TITLE
chore: do not compile existing packages

### DIFF
--- a/.github/workflows/verifyimage.yml
+++ b/.github/workflows/verifyimage.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - develop
+
 env:
   REPO: "owasp/modsecurity"
 

--- a/v2-apache/Dockerfile
+++ b/v2-apache/Dockerfile
@@ -2,9 +2,7 @@ ARG APACHE_VERSION=2.4
 
 FROM httpd:${APACHE_VERSION} as build
 
-ARG MODSEC_VERSION=2.9.6 \
-    SSDEEP_VERSION=2.14.1 \
-    FUZZY_VERSION=2.1.0
+ARG MODSEC_VERSION=2.9.6
 
 RUN set -eux; \
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections; \
@@ -17,6 +15,7 @@ RUN set -eux; \
         libapr1-dev \
         libaprutil1-dev \
         libcurl4-gnutls-dev \
+        libfuzzy-dev \
         libpcre++-dev \
         libtool \
         libxml2-dev \
@@ -27,19 +26,11 @@ RUN set -eux; \
         wget
 
 RUN set -eux; \
-    wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    cd ssdeep-${SSDEEP_VERSION}; \
-    ./configure; \
-    make; \
-    make install; \
-    make clean
-
-RUN set -eux; \
-    git clone https://github.com/SpiderLabs/ModSecurity --branch v${MODSEC_VERSION} --depth 1; \
-    cd ModSecurity; \
+    wget --quiet https://github.com/SpiderLabs/ModSecurity/archive/refs/tags/v${MODSEC_VERSION}.tar.gz; \
+    tar -zxvf v${MODSEC_VERSION}.tar.gz; \
+    cd ModSecurity-${MODSEC_VERSION}; \
     ./autogen.sh; \
-    ./configure; \
+    ./configure --with-yajl --with-ssdeep; \
     make; \
     make install; \
     make clean
@@ -54,9 +45,7 @@ RUN openssl req -x509 -days 365 -new \
 
 FROM httpd:${APACHE_VERSION}
 
-ARG MODSEC_VERSION=2.9.6 \
-    SSDEEP_VERSION=2.14.1 \
-    FUZZY_VERSION=2.1.0
+ARG MODSEC_VERSION=2.9.6
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 
@@ -132,6 +121,7 @@ RUN set -eux; \
     apt-get install -qq -y --no-install-recommends --no-install-suggests \
         ca-certificates \
         libcurl3-gnutls \
+        libfuzzy2 \
         libxml2 \
         libyajl2; \
     apt-get clean; \
@@ -144,19 +134,12 @@ RUN set -eux; \
     mkdir -p /var/log/apache2/
 
 COPY --from=build /usr/local/apache2/modules/mod_security2.so                  /usr/local/apache2/modules/mod_security2.so
-COPY --from=build /usr/local/apache2/ModSecurity/modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf
-COPY --from=build /usr/local/apache2/ModSecurity/unicode.mapping               /etc/modsecurity.d/unicode.mapping
-COPY --from=build /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}                  /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}
-COPY --from=build /usr/local/bin/ssdeep                                        /usr/local/bin/ssdeep
+COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf
+COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/unicode.mapping               /etc/modsecurity.d/unicode.mapping
 COPY --from=build /usr/share/TLS/server.key                                    /usr/local/apache2/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt                                    /usr/local/apache2/conf/server.crt
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY v2-apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
-
-RUN set -eux; \
-    ln -s libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so; \
-    ln -s libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so.2; \
-    ldconfig
 
 RUN set -eux; \
     sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf; \

--- a/v2-apache/Dockerfile-alpine
+++ b/v2-apache/Dockerfile-alpine
@@ -2,9 +2,7 @@ ARG APACHE_VERSION=2.4
 
 FROM httpd:${APACHE_VERSION}-alpine as build
 
-ARG MODSEC_VERSION=2.9.6 \
-    SSDEEP_VERSION=2.14.1 \
-    FUZZY_VERSION=2.1.0
+ARG MODSEC_VERSION=2.9.6
 
 # see https://httpd.apache.org/docs/2.4/install.html#requirements
 RUN set -eux; \
@@ -22,6 +20,7 @@ RUN set -eux; \
     g++ \
     gnupg \
     libc-dev \
+    libfuzzy2-dev \
     libmaxminddb-dev \
     libstdc++ \
     linux-headers \
@@ -35,17 +34,6 @@ RUN set -eux; \
     openssl-dev \
     pcre-dev \
     zlib-dev
-
-
-# This one is in edge still for Alpine, so just compile
-RUN set -eux; \
-    wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    cd ssdeep-${SSDEEP_VERSION}; \
-    ./configure; \
-    make; \
-    make install; \
-    make clean
 
 RUN set -eux; \
     wget --quiet https://github.com/SpiderLabs/ModSecurity/archive/refs/tags/v${MODSEC_VERSION}.tar.gz; \
@@ -67,9 +55,7 @@ RUN openssl req -x509 -days 365 -new \
 
 FROM httpd:${APACHE_VERSION}-alpine
 
-ARG MODSEC_VERSION=2.9.6 \
-    SSDEEP_VERSION=2.14.1 \
-    FUZZY_VERSION=2.1.0
+ARG MODSEC_VERSION=2.9.6 
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 
@@ -142,6 +128,7 @@ ENV APACHE_ALWAYS_TLS_REDIRECT=off \
 RUN set -eux; \
     apk add --no-cache \
     ca-certificates \
+    libfuzzy2 \
     libxml2 \
     moreutils \
     tzdata \
@@ -150,15 +137,12 @@ RUN set -eux; \
 COPY --from=build /usr/local/apache2/modules/mod_security2.so                  /usr/local/apache2/modules/mod_security2.so
 COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/modsecurity.conf-recommended  /etc/modsecurity.d/modsecurity.conf
 COPY --from=build /usr/local/apache2/ModSecurity-${MODSEC_VERSION}/unicode.mapping               /etc/modsecurity.d/unicode.mapping
-COPY --from=build /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}                  /usr/local/lib/libfuzzy.so.${FUZZY_VERSION}
-COPY --from=build /usr/local/bin/ssdeep                                        /usr/local/bin/ssdeep
 COPY --from=build /usr/share/TLS/server.key                                    /usr/local/apache2/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt                                    /usr/local/apache2/conf/server.crt
 COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 COPY v2-apache/conf/extra/*.conf /usr/local/apache2/conf/extra/
 
 RUN set -eux; \
-    ln -s /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so.2; \
     sed -i -E 's|(Listen) [0-9]+|\1 ${PORT}|' /usr/local/apache2/conf/httpd.conf; \
     sed -i -E 's|(ServerTokens) Full|\1 Prod|' /usr/local/apache2/conf/extra/httpd-default.conf; \
     sed -i -E 's|#(ServerName) www.example.com:80|\1 ${SERVER_NAME}|' /usr/local/apache2/conf/httpd.conf; \

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -3,10 +3,7 @@ ARG NGINX_VERSION="1.22.0"
 FROM nginx:${NGINX_VERSION} as build
 
 ARG MODSEC_VERSION=3.0.8 \
-    YAJL_VERSION=2.1.0 \
-    FUZZY_VERSION=2.1.0 \
-    LMDB_VERSION=0.9.29 \
-    SSDEEP_VERSION=2.14.1
+    LMDB_VERSION=0.9.29
 
 # Note: libpcre++-dev (PCRE3) is required by the build description,
 # even though the build will use PCRE2.
@@ -20,12 +17,14 @@ RUN set -eux; \
         g++ \
         git \
         libcurl4-gnutls-dev \
+        libfuzzy-dev \
         libgeoip-dev \
         liblua5.3-dev \
         libpcre++-dev \
         libpcre2-dev \
         libtool \
         libxml2-dev \
+        libyajl-dev \
         make \
         patch \
         pkg-config \
@@ -42,26 +41,11 @@ RUN set -eux; \
     strip /usr/local/lib/liblmdb*.so*
 
 RUN set -eux; \
-    git clone https://github.com/lloyd/yajl --branch ${YAJL_VERSION} --depth 1; \
-    cd yajl; \
-    ./configure; \
-    make install; \
-    strip /usr/local/lib/libyajl*.so*
-
-RUN set -eux; \
-    curl -sSL https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz -o ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    cd ssdeep-${SSDEEP_VERSION}; \
-    ./configure; \
-    make install; \
-    strip /usr/local/lib/libfuzzy*.so*
-
-RUN set -eux; \
     git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
     curl -sSL https://github.com/SpiderLabs/ModSecurity/pull/2813.patch -o - | patch -p1; \
     ./build.sh; \
-    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2 --enable-silent-rules; \
+    ./configure --with-yajl --with-ssdeep --with-geoip --with-pcre2 --enable-silent-rules; \
     make install; \
     strip /usr/local/modsecurity/lib/lib*.so*
 
@@ -97,10 +81,7 @@ RUN curl -sSL https://ssl-config.mozilla.org/ffdhe4096.txt -o /usr/share/TLS/dhp
 FROM nginx:${NGINX_VERSION}
 
 ARG MODSEC_VERSION=3.0.8 \
-    YAJL_VERSION=2.1.0 \
-    FUZZY_VERSION=2.1.0 \
-    LMDB_VERSION=0.9.29 \
-    SSDEEP_VERSION=2.14.1
+    LMDB_VERSION=0.9.29
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 
@@ -167,8 +148,10 @@ RUN set -eux; \
     LD_LIBRARY_PATH="" apt-get install -y -qq --no-install-recommends --no-install-suggests \
         ca-certificates \
         libcurl4-gnutls-dev \
+        libfuzzy2 \
         liblua5.3 \
         libxml2 \
+        libyajl2 \
         moreutils; \
     rm -rf /var/lib/apt/lists/*; \
     apt-get clean; \
@@ -180,9 +163,7 @@ RUN set -eux; \
     chown -R nginx:nginx /tmp/modsecurity
 
 COPY --from=build /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/
-COPY --from=build /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/
 COPY --from=build /etc/nginx/modules/ngx_http_modsecurity_module.so /etc/nginx/modules/ngx_http_modsecurity_module.so
-COPY --from=build /usr/local/lib/libyajl.so.${YAJL_VERSION} /usr/local/lib/
 COPY --from=build /usr/local/lib/liblmdb.so /usr/local/lib/
 COPY --from=build /usr/share/TLS/server.key /etc/nginx/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt /etc/nginx/conf/server.crt
@@ -201,9 +182,5 @@ RUN set -eux; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so.3.0; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so.3; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so; \
-    ln -s /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so; \
-    ln -s /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so.2; \
-    ln -s /usr/local/lib/libyajl.so.${YAJL_VERSION} /usr/local/lib/libyajl.so; \
-    ln -s /usr/local/lib/libyajl.so.${YAJL_VERSION} /usr/local/lib/libyajl.so.2; \
     chgrp -R 0 /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/; \
     chmod -R g=u /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -2,9 +2,7 @@ ARG NGINX_VERSION="1.22.0"
 
 FROM nginx:${NGINX_VERSION}-alpine as build
 
-ARG MODSEC_VERSION=3.0.8 \
-    FUZZY_VERSION=2.1.0 \
-    SSDEEP_VERSION=2.14.1
+ARG MODSEC_VERSION=3.0.8
 
 # Note: pcre-dev (PCRE3) is required by the build description,
 # even though the build will use PCRE2.
@@ -20,6 +18,7 @@ RUN set -eux; \
         geoip-dev \
         git \
         libc-dev \
+        libfuzzy2-dev \        
         libmaxminddb-dev \
         libstdc++ \
         libtool \
@@ -37,13 +36,6 @@ RUN set -eux; \
         zlib-dev
 
 WORKDIR /sources
-
-RUN set -eux; \
-    wget --quiet https://github.com/ssdeep-project/ssdeep/releases/download/release-${SSDEEP_VERSION}/ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    tar -xvzf ssdeep-${SSDEEP_VERSION}.tar.gz; \
-    cd ssdeep-${SSDEEP_VERSION}; \
-    ./configure; \
-    make install
 
 RUN set -eux; \
     git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
@@ -84,9 +76,7 @@ RUN curl -sSL https://ssl-config.mozilla.org/ffdhe4096.txt -o /usr/share/TLS/dhp
 
 FROM nginx:${NGINX_VERSION}-alpine
 
-ARG MODSEC_VERSION=3.0.8 \
-    FUZZY_VERSION=2.1.0 \
-    SSDEEP_VERSION=2.14.1
+ARG MODSEC_VERSION=3.0.8
 
 LABEL maintainer="Felipe Zipitria <felipe.zipitria@owasp.org>"
 
@@ -150,6 +140,7 @@ ENV ACCESSLOG=/var/log/nginx/access.log \
 RUN set -eux; \
     apk add --no-cache \
         curl-dev \
+        libfuzzy2 \
         libmaxminddb-dev \
         libstdc++ \
         libxml2-dev \
@@ -166,7 +157,6 @@ RUN set -eux; \
     chown -R nginx:nginx /usr/share/nginx /tmp/modsecurity
 
 COPY --from=build /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/
-COPY --from=build /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/
 COPY --from=build /etc/nginx/modules/ngx_http_modsecurity_module.so /etc/nginx/modules/ngx_http_modsecurity_module.so
 COPY --from=build /usr/share/TLS/server.key /etc/nginx/conf/server.key
 COPY --from=build /usr/share/TLS/server.crt /etc/nginx/conf/server.crt
@@ -185,8 +175,6 @@ RUN set -eux; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so.3.0; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so.3; \
     ln -s /usr/local/modsecurity/lib/libmodsecurity.so.${MODSEC_VERSION} /usr/local/modsecurity/lib/libmodsecurity.so; \
-    ln -s /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so; \
-    ln -s /usr/local/lib/libfuzzy.so.${FUZZY_VERSION} /usr/local/lib/libfuzzy.so.2; \
     chgrp -R 0 /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/; \
     chmod -R g=u /var/cache/nginx/ /var/log/ /var/run/ /usr/share/nginx/ /etc/nginx/ /etc/modsecurity.d/
 


### PR DESCRIPTION
- packages are already available in major distributions
- remove compilation steps for ssdeep and variables
- remove libfuzzy variables

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Fixes #142.