### PR TITLE
bugfix: clean up log formats

### DIFF
--- a/v2-apache/conf/extra/httpd-modsecurity.conf
+++ b/v2-apache/conf/extra/httpd-modsecurity.conf
@@ -2,6 +2,7 @@ LoadModule security2_module /usr/local/apache2/modules/mod_security2.so
 
 Timeout ${TIMEOUT}
 
+# The "common" and "combined" formats are predefined
 LogFormat ${APACHE_LOGFORMAT} modsec
 LogFormat ${APACHE_METRICS_LOGFORMAT} metricslog
 

--- a/v3-nginx/templates/conf.d/logging.conf.template
+++ b/v3-nginx/templates/conf.d/logging.conf.template
@@ -1,3 +1,4 @@
+# The "combined" log format is predefined
 log_format main '$realip_remote_addr - $remote_user [$time_local] "$request" '
                 '$status $body_bytes_sent "$http_referer" '
                 '"$http_user_agent" "$http_x_forwarded_for"';


### PR DESCRIPTION
- The `perflogjson` format did not exist and the `PERFLOG` environment variable had no effect because `write_perflog` was never set.
- Add comments about predefined log formats

Fixes #128