### PR TITLE
fix(pcre2): add prefix path for additional archs

### DIFF
--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -61,7 +61,8 @@ RUN set -eux; \
     ./build.sh; \
     git submodule init; \
     git submodule update; \
-    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2="$(pcre2-config --prefix)"; \
+    sed -i -e 's/^PCRE2_POSSIBLE_LIB_NAMES=\(.*\)"/PCRE2_POSSIBLE_LIB_NAMES=\1 libpcre2-8"/' build/pcre2.m4 ; \
+    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2; \
     make install; \
     strip /usr/local/modsecurity/lib/lib*.so*
 

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux; \
     git submodule init; \
     git submodule update; \
     # patch make file to support Debian package names (see https://github.com/SpiderLabs/ModSecurity/issues/2810) \
-    sed -i -e 's/^PCRE2_POSSIBLE_LIB_NAMES=\(.*\)"/PCRE2_POSSIBLE_LIB_NAMES=\1 libpcre2-8"/' build/pcre2.m4 ; \
+    sed -i -e 's/^\(PCRE2_POSSIBLE_LIB_NAMES=.*\)"/\1 libpcre2-8"/' build/pcre2.m4; \
     ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2; \
     make install; \
     strip /usr/local/modsecurity/lib/lib*.so*

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -61,6 +61,7 @@ RUN set -eux; \
     ./build.sh; \
     git submodule init; \
     git submodule update; \
+    # patch make file to support Debian package names (see https://github.com/SpiderLabs/ModSecurity/issues/2810) \
     sed -i -e 's/^PCRE2_POSSIBLE_LIB_NAMES=\(.*\)"/PCRE2_POSSIBLE_LIB_NAMES=\1 libpcre2-8"/' build/pcre2.m4 ; \
     ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2; \
     make install; \

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -61,7 +61,7 @@ RUN set -eux; \
     ./build.sh; \
     git submodule init; \
     git submodule update; \
-    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2; \
+    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2="$(pcre2-config --prefix)"; \
     make install; \
     strip /usr/local/modsecurity/lib/lib*.so*
 

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -50,7 +50,7 @@ RUN set -eux; \
     ./build.sh; \
     git submodule init; \
     git submodule update; \
-    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2; \
+    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2="$(pcre2-config --prefix)"; \
     make install
 
 # We use master

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -52,7 +52,7 @@ RUN set -eux; \
     git submodule update; \
     # patch make file to support Debian package names (see https://github.com/SpiderLabs/ModSecurity/issues/2810) \
     sed -i -e 's/^\(PCRE2_POSSIBLE_LIB_NAMES=.*\)"/\1 libpcre2-8"/' build/pcre2.m4; \
-    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2="$(pcre2-config --prefix)"; \
+    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2; \
     make install
 
 # We use master

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -50,6 +50,7 @@ RUN set -eux; \
     ./build.sh; \
     git submodule init; \
     git submodule update; \
+    # patch make file to support Debian package names (see https://github.com/SpiderLabs/ModSecurity/issues/2810) \
     sed -i -e 's/^PCRE2_POSSIBLE_LIB_NAMES=\(.*\)"/PCRE2_POSSIBLE_LIB_NAMES=\1 libpcre2-8"/' build/pcre2.m4 ; \
     ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2="$(pcre2-config --prefix)"; \
     make install

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -50,6 +50,7 @@ RUN set -eux; \
     ./build.sh; \
     git submodule init; \
     git submodule update; \
+    sed -i -e 's/^PCRE2_POSSIBLE_LIB_NAMES=\(.*\)"/PCRE2_POSSIBLE_LIB_NAMES=\1 libpcre2-8"/' build/pcre2.m4 ; \
     ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2="$(pcre2-config --prefix)"; \
     make install
 

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -51,7 +51,7 @@ RUN set -eux; \
     git submodule init; \
     git submodule update; \
     # patch make file to support Debian package names (see https://github.com/SpiderLabs/ModSecurity/issues/2810) \
-    sed -i -e 's/^PCRE2_POSSIBLE_LIB_NAMES=\(.*\)"/PCRE2_POSSIBLE_LIB_NAMES=\1 libpcre2-8"/' build/pcre2.m4 ; \
+    sed -i -e 's/^\(PCRE2_POSSIBLE_LIB_NAMES=.*\)"/\1 libpcre2-8"/' build/pcre2.m4; \
     ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2="$(pcre2-config --prefix)"; \
     make install
 


### PR DESCRIPTION
On debian arm64 path is /usr/lib/aarch64-linux-gnu, and looks like the autoconf script is not finding libraries there.

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>