### PR TITLE
fix(pcre2): apply patch from upstream modsec repo

### DIFF
--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -27,8 +27,9 @@ RUN set -eux; \
         libtool \
         libxml2-dev \
         make \
-        ruby \
+        patch \
         pkg-config \
+        ruby \
         zlib1g-dev; \
      apt-get clean; \
      rm -rf /var/lib/apt/lists/*
@@ -56,14 +57,11 @@ RUN set -eux; \
     strip /usr/local/lib/libfuzzy*.so*
 
 RUN set -eux; \
-    git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1; \
+    git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
+    curl -sSL https://github.com/SpiderLabs/ModSecurity/pull/2813.patch -o - | patch -p1; \
     ./build.sh; \
-    git submodule init; \
-    git submodule update; \
-    # patch make file to support Debian package names (see https://github.com/SpiderLabs/ModSecurity/issues/2810) \
-    sed -i -e 's/^\(PCRE2_POSSIBLE_LIB_NAMES=.*\)"/\1 libpcre2-8"/' build/pcre2.m4; \
-    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2; \
+    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2  --enable-silent-rules; \
     make install; \
     strip /usr/local/modsecurity/lib/lib*.so*
 

--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -61,7 +61,7 @@ RUN set -eux; \
     cd ModSecurity; \
     curl -sSL https://github.com/SpiderLabs/ModSecurity/pull/2813.patch -o - | patch -p1; \
     ./build.sh; \
-    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2  --enable-silent-rules; \
+    ./configure --with-yajl=/sources/yajl/build/yajl-${YAJL_VERSION}/ --with-geoip --with-pcre2 --enable-silent-rules; \
     make install; \
     strip /usr/local/modsecurity/lib/lib*.so*
 

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -156,6 +156,8 @@ RUN set -eux; \
         lmdb-dev \
         moreutils \
         tzdata \
+        pcre \
+        pcre2 \
         yajl; \
     mkdir /etc/nginx/ssl/; \
     mkdir -p /tmp/modsecurity/data; \

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -50,7 +50,7 @@ RUN set -eux; \
     cd ModSecurity; \
     curl -sSL https://github.com/SpiderLabs/ModSecurity/pull/2813.patch -o - | patch -p1; \
     ./build.sh; \
-    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2  --enable-silent-rules; \
+    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2 --enable-silent-rules; \
     make install; \
     strip /usr/local/modsecurity/lib/lib*.so*
 

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -29,6 +29,7 @@ RUN set -eux; \
         make \
         openssl \
         openssl-dev \
+        patch \
         pkgconfig \
         pcre-dev \
         pcre2-dev \
@@ -45,15 +46,13 @@ RUN set -eux; \
     make install
 
 RUN set -eux; \
-    git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1; \
+    git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
+    curl -sSL https://github.com/SpiderLabs/ModSecurity/pull/2813.patch -o - | patch -p1; \
     ./build.sh; \
-    git submodule init; \
-    git submodule update; \
-    # patch make file to support Debian package names (see https://github.com/SpiderLabs/ModSecurity/issues/2810) \
-    sed -i -e 's/^\(PCRE2_POSSIBLE_LIB_NAMES=.*\)"/\1 libpcre2-8"/' build/pcre2.m4; \
-    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2; \
-    make install
+    ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2  --enable-silent-rules; \
+    make install; \
+    strip /usr/local/modsecurity/lib/lib*.so*
 
 # We use master
 RUN set -eux; \


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

The previous attempt using sed still failed on some architectures.

To fix the problem I've sent a PR for upstream modsecurity build process. While it is not merged, we add it here to the build.

- add the patch from PR 2813
- enable silent build (saves a ton of scrolling when building)
- just clone recursively instead of doing it in two steps
- strip binaries also in alpine