### PR TITLE
fix(nginx): use host cpu instead of fixed archs

### DIFF
--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -43,7 +43,9 @@ RUN set -eux; \
 RUN set -eux; \
     git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
-    curl -sSL https://github.com/SpiderLabs/ModSecurity/pull/2813.patch -o - | patch -p1; \
+    sed -ie 's/\(PKG_PROG_PKG_CONFIG\)/\1\nAC_CANONICAL_HOST/g' configure.ac; \
+    sed -ie 's/i386/${host_cpu}/g' build/ssdeep.m4; \
+    sed -ie 's/i386/${host_cpu}/g' build/pcre2.m4; \
     ./build.sh; \
     ./configure --with-yajl --with-ssdeep --with-geoip --with-pcre2 --enable-silent-rules; \
     make install; \

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -40,7 +40,9 @@ WORKDIR /sources
 RUN set -eux; \
     git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
-    curl -sSL https://github.com/SpiderLabs/ModSecurity/pull/2813.patch -o - | patch -p1; \
+    sed -ie 's/\(PKG_PROG_PKG_CONFIG\)/\1\nAC_CANONICAL_HOST/g' configure.ac; \
+    sed -ie 's/i386/${host_cpu}/g' build/ssdeep.m4; \
+    sed -ie 's/i386/${host_cpu}/g' build/pcre2.m4; \
     ./build.sh; \
     ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2 --enable-silent-rules; \
     make install; \


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- this trick makes both ssdeep and pcre2 be found in other architectures
- we need `AC_CANONICAL_HOST` earlier in the `configure.ac` file to use its defined the variable `$host_cpu`