### PR TITLE
fix(nginx): i386 is detected as x86_64 in build

### DIFF
--- a/v3-nginx/Dockerfile
+++ b/v3-nginx/Dockerfile
@@ -44,8 +44,8 @@ RUN set -eux; \
     git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
     sed -ie 's/\(PKG_PROG_PKG_CONFIG\)/\1\nAC_CANONICAL_HOST/g' configure.ac; \
-    sed -ie 's/i386/${host_cpu}/g' build/ssdeep.m4; \
-    sed -ie 's/i386/${host_cpu}/g' build/pcre2.m4; \
+    sed -ie 's/x86_64/${host_cpu}/g' build/ssdeep.m4; \
+    sed -ie 's/x86_64/${host_cpu}/g' build/pcre2.m4; \
     ./build.sh; \
     ./configure --with-yajl --with-ssdeep --with-geoip --with-pcre2 --enable-silent-rules; \
     make install; \

--- a/v3-nginx/Dockerfile-alpine
+++ b/v3-nginx/Dockerfile-alpine
@@ -41,8 +41,8 @@ RUN set -eux; \
     git clone https://github.com/SpiderLabs/ModSecurity --branch v"${MODSEC_VERSION}" --depth 1 --recursive; \
     cd ModSecurity; \
     sed -ie 's/\(PKG_PROG_PKG_CONFIG\)/\1\nAC_CANONICAL_HOST/g' configure.ac; \
-    sed -ie 's/i386/${host_cpu}/g' build/ssdeep.m4; \
-    sed -ie 's/i386/${host_cpu}/g' build/pcre2.m4; \
+    sed -ie 's/x86_64/${host_cpu}/g' build/ssdeep.m4; \
+    sed -ie 's/x86_64/${host_cpu}/g' build/pcre2.m4; \
     ./build.sh; \
     ./configure --with-yajl --with-ssdeep --with-lmdb --with-geoip --with-pcre2 --enable-silent-rules; \
     make install; \


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Turns out i386 is detected by `uname -m` as x86_64, therefore it still fails to find libraries in that arch. Doing the same change but on x86_64 made both work, and also arm builds.